### PR TITLE
日本語化対応

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,10 @@ gem "bootsnap", require: false
 # User functions
 gem 'devise'
 
+# localization
+gem 'rails-i18n'
+gem 'devise-i18n'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,8 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    devise-i18n (1.11.0)
+      devise (>= 4.9.0)
     erubi (1.12.0)
     globalid (1.1.0)
       activesupport (>= 5.0)
@@ -154,6 +156,9 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
+    rails-i18n (7.0.7)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.0.6)
       actionpack (= 7.0.6)
       activesupport (= 7.0.6)
@@ -205,11 +210,13 @@ DEPENDENCIES
   cssbundling-rails
   debug
   devise
+  devise-i18n
   jbuilder
   jsbundling-rails
   pg (~> 1.1)
   puma (~> 5.0)
   rails (~> 7.0.6)
+  rails-i18n
   sprockets-rails
   stimulus-rails
   turbo-rails

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -4,7 +4,7 @@
     <p class="text-gray-900">© 2023 - All right reserved</p>
   </div> 
   <div class="flex">
-    <%= link_to 'プライバシーポリシー', privacy_policy_path, class: 'mr-5 text-gray-900' %>
-    <%= link_to '利用規約', terms_path, class: 'mr-5 text-gray-900' %>
+    <%= link_to t('defaults.privacy_policy'), privacy_policy_path, class: 'mr-5 text-gray-900' %>
+    <%= link_to t('defaults.terms'), terms_path, class: 'mr-5 text-gray-900' %>
   </div>
 </footer>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -7,9 +7,9 @@
   </div>
   <div class="drawer-end flex items-center">  
     <% if user_signed_in? %>  
-      <%= link_to 'ログアウト', destroy_user_session_path, data: { turbo_method: :delete }, class: 'mr-5' %>
+      <%= link_to t('defaults.sign_out'), destroy_user_session_path, data: { turbo_method: :delete }, class: 'mr-5' %>
     <% else %>
-      <%= link_to 'ログイン', new_user_session_path, class: 'mr-5' %>
+      <%= link_to t('defaults.sign_in'), new_user_session_path, class: 'mr-5' %>
     <% end %>
     <input id="my-drawer-4" type="checkbox" class="drawer-toggle" />
     <label for="my-drawer-4" class="drawer-button">
@@ -18,12 +18,12 @@
     <div class="drawer-side">
       <label for="my-drawer-4" class="drawer-overlay"></label>
       <ul class="menu p-4 w-80 h-full bg-yellow-50 text-base-content">
-        <%= link_to 'ホーム', '#', class: 'mt-10 text-sm border-b border-gray-500 pb-2' %>
-        <%= link_to 'マイページ', '#', class: 'mt-10 text-sm border-b border-gray-500 pb-2' %>
-        <%= link_to 'セレクトショップから検索', '#', class: 'mt-10 text-sm border-b border-gray-500 pb-2' %>
-        <%= link_to 'カフェから検索', '#', class: 'mt-10 text-sm border-b border-gray-500 pb-2' %>
-        <%= link_to 'ブランドから検索', '#', class: 'mt-10 text-sm border-b border-gray-500 pb-2' %>
-        <%= link_to '保存済み', '#', class: 'mt-10 text-sm border-b border-gray-500 pb-2' %>
+        <%= link_to t('defaults.home'), '#', class: 'mt-10 text-sm border-b border-gray-500 pb-2' %>
+        <%= link_to t('defaults.mypage'), '#', class: 'mt-10 text-sm border-b border-gray-500 pb-2' %>
+        <%= link_to t('defaults.search_shop'), '#', class: 'mt-10 text-sm border-b border-gray-500 pb-2' %>
+        <%= link_to t('defaults.search_cafe'), '#', class: 'mt-10 text-sm border-b border-gray-500 pb-2' %>
+        <%= link_to t('defaults.search_brand'), '#', class: 'mt-10 text-sm border-b border-gray-500 pb-2' %>
+        <%= link_to t('defaults.saved'), '#', class: 'mt-10 text-sm border-b border-gray-500 pb-2' %>
       </ul>
     </div>
   </div>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -9,8 +9,8 @@
         あなた好みのお店はきっとそこにある
       </p>
       <div class="mt-32 flex">
-        <%= link_to 'マップから探す', '#', class: 'bg-orange-300 py-4 px-16 rounded-xl mr-10 text-xl' %>
-        <%= link_to '新規登録', new_user_registration_path, class: 'bg-gray-300 py-4 px-16 rounded-xl text-xl' %>
+        <%= link_to t('defaults.search_map'), '#', class: 'bg-orange-300 py-4 px-16 rounded-xl mr-10 text-xl' %>
+        <%= link_to t('defaults.sign_up'), new_user_registration_path, class: 'bg-gray-300 py-4 px-16 rounded-xl text-xl' %>
       </div>
     </div>
   </div>

--- a/app/views/users/confirmations/new.html.erb
+++ b/app/views/users/confirmations/new.html.erb
@@ -1,4 +1,4 @@
-<h2>Resend confirmation instructions</h2>
+<h2><%= t('.resend_confirmation_instructions') %></h2>
 
 <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
   <%= render "users/shared/error_messages", resource: resource %>
@@ -9,7 +9,7 @@
   </div>
 
   <div class="actions">
-    <%= f.submit "Resend confirmation instructions" %>
+    <%= f.submit t('.resend_confirmation_instructions') %>
   </div>
 <% end %>
 

--- a/app/views/users/mailer/confirmation_instructions.html.erb
+++ b/app/views/users/mailer/confirmation_instructions.html.erb
@@ -1,5 +1,5 @@
-<p>Welcome <%= @email %>!</p>
+<p><%= t('.greeting', recipient: @email) %></p>
 
-<p>You can confirm your account email through the link below:</p>
+<p><%= t('.instruction') %></p>
 
-<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>
+<p><%= link_to t('.action'), confirmation_url(@resource, confirmation_token: @token) %></p>

--- a/app/views/users/mailer/email_changed.html.erb
+++ b/app/views/users/mailer/email_changed.html.erb
@@ -1,7 +1,7 @@
-<p>Hello <%= @email %>!</p>
+<p><%= t('.greeting', recipient: @email) %></p>
 
 <% if @resource.try(:unconfirmed_email?) %>
-  <p>We're contacting you to notify you that your email is being changed to <%= @resource.unconfirmed_email %>.</p>
+  <p><%= t('.message_unconfirmed', email: @resource.unconfirmed_email) %></p>
 <% else %>
-  <p>We're contacting you to notify you that your email has been changed to <%= @resource.email %>.</p>
+  <p><%= t('.message', email: @resource.email) %></p>
 <% end %>

--- a/app/views/users/mailer/password_change.html.erb
+++ b/app/views/users/mailer/password_change.html.erb
@@ -1,3 +1,3 @@
-<p>Hello <%= @resource.email %>!</p>
+<p><%= t('.greeting', recipient: @resource.email) %></p>
 
-<p>We're contacting you to notify you that your password has been changed.</p>
+<p><%= t('.message') %></p>

--- a/app/views/users/mailer/reset_password_instructions.html.erb
+++ b/app/views/users/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,8 @@
-<p>Hello <%= @resource.email %>!</p>
+<p><%= t('.greeting', recipient: @resource.email) %></p>
 
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+<p><%= t('.instruction') %></p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+<p><%= link_to t('.action'), edit_password_url(@resource, reset_password_token: @token) %></p>
 
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>
+<p><%= t('.instruction_2') %></p>
+<p><%= t('.instruction_3') %></p>

--- a/app/views/users/mailer/unlock_instructions.html.erb
+++ b/app/views/users/mailer/unlock_instructions.html.erb
@@ -1,7 +1,7 @@
-<p>Hello <%= @resource.email %>!</p>
+<p><%= t('.greeting', recipient: @resource.email) %></p>
 
-<p>Your account has been locked due to an excessive number of unsuccessful sign in attempts.</p>
+<p><%= t('.message') %></p>
 
-<p>Click the link below to unlock your account:</p>
+<p><%= t('.instruction') %></p>
 
-<p><%= link_to 'Unlock my account', unlock_url(@resource, unlock_token: @token) %></p>
+<p><%= link_to t('.action'), unlock_url(@resource, unlock_token: @token) %></p>

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -1,24 +1,24 @@
-<h2>Change your password</h2>
+<h2><%= t('.change_your_password') %></h2>
 
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
   <%= render "users/shared/error_messages", resource: resource %>
   <%= f.hidden_field :reset_password_token %>
 
   <div class="field">
-    <%= f.label :password, "New password" %><br />
+    <%= f.label :password, t('.new_password') %><br />
     <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
+      <em><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></em><br />
     <% end %>
     <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
   </div>
 
   <div class="field">
-    <%= f.label :password_confirmation, "Confirm new password" %><br />
+    <%= f.label :password_confirmation, t('.confirm_new_password') %><br />
     <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
   </div>
 
   <div class="actions">
-    <%= f.submit "Change my password" %>
+    <%= f.submit t('.change_my_password') %>
   </div>
 <% end %>
 

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -9,11 +9,11 @@
 
         <div class="form-control ">
           <%= f.label :email, class: 'label-text text-xl' %>
-          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'input input-warning border-gray-800 border-opacity-50 bg-yellow-50', placeholder: 'sample@sample.com' %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'input input-warning border-gray-800 border-opacity-50 bg-yellow-50', placeholder: t('placeholders.email') %>
         </div>
 
         <div class="actions">
-          <%= f.submit "送信", class: 'btn btn-wide btn-neutral w-full mt-10' %>
+          <%= f.submit t('.sent'), class: 'btn btn-wide btn-neutral w-full mt-10' %>
         </div>
       <% end %>
     </div>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -1,4 +1,4 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<h2><%= t('.title', resource: resource_name.to_s.humanize) %></h2>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
   <%= render "users/shared/error_messages", resource: resource %>
@@ -9,15 +9,15 @@
   </div>
 
   <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+    <div><%= t('.currently_waiting_confirmation_for_email', email: resource.unconfirmed_email) %></div>
   <% end %>
 
   <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
+    <%= f.label :password %> <i>(<%= t('.leave_blank_if_you_don_t_want_to_change_it') %>)</i><br />
     <%= f.password_field :password, autocomplete: "new-password" %>
     <% if @minimum_password_length %>
       <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
+      <em><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></em>
     <% end %>
   </div>
 
@@ -27,17 +27,17 @@
   </div>
 
   <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
+    <%= f.label :current_password %> <i>(<%= t('.we_need_your_current_password_to_confirm_your_changes') %>)</i><br />
     <%= f.password_field :current_password, autocomplete: "current-password" %>
   </div>
 
   <div class="actions">
-    <%= f.submit "Update" %>
+    <%= f.submit t('.update') %>
   </div>
 <% end %>
 
-<h3>Cancel my account</h3>
+<h3><%= t('.cancel_my_account') %></h3>
 
-<div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div>
+<div><%= t('.unhappy') %> <%= button_to t('.cancel_my_account'), registration_path(resource_name), data: { confirm: t('.are_you_sure'), turbo_confirm: t('.are_you_sure') }, method: :delete %></div>
 
-<%= link_to "Back", :back %>
+<%= link_to t('devise.shared.links.back'), :back %>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,7 +1,7 @@
 <div class="container mx-auto mb-20">
   <div class="px-5 border-opacity-50">
     <div class="grid place-items-center">
-      <h2 class="place-items-centeer my-6 text-2xl text-bold">新規登録</h2>
+      <h2 class="place-items-centeer my-6 text-2xl text-bold"><%= t('.sign_up') %></h2>
     </div>
     <div class="grid place-items-center">
       <%= form_with model: resource, url: registration_path(resource_name), class: 'w-full px-5 md:w-3/5 md:px-0',  local: true do |f| %>
@@ -9,26 +9,26 @@
 
         <div class="form-control">
           <%= f.label :name, class: 'label-text text-xl' %>
-          <%= f.text_field :name, autofocus: true, autocomplete: "name", class: 'input input-warning border-gray-800 border-opacity-50 bg-yellow-50', placeholder: '○文字以内で入力ください' %>
+          <%= f.text_field :name, autofocus: true, autocomplete: "name", class: 'input input-warning border-gray-800 border-opacity-50 bg-yellow-50', placeholder: t('placeholders.name') %>
         </div>
 
         <div class="form-control mt-5">
           <%= f.label :email, class: 'label-text text-xl' %>
-          <%= f.email_field :email, autocomplete: "email", class: 'input input-warning border-gray-800 border-opacity-50 bg-yellow-50', placeholder: 'sample@sample.com' %>
+          <%= f.email_field :email, autocomplete: "email", class: 'input input-warning border-gray-800 border-opacity-50 bg-yellow-50', placeholder: t('placeholders.email') %>
         </div>
 
         <div class="form-control mt-5">
           <%= f.label :password, class: 'label-text text-xl' %>
-          <%= f.password_field :password, autocomplete: "new-password", class: 'input input-warning border-gray-800 border-opacity-50 bg-yellow-50', placeholder: '半角英数字6文字以上を入力ください' %>
+          <%= f.password_field :password, autocomplete: "new-password", class: 'input input-warning border-gray-800 border-opacity-50 bg-yellow-50', placeholder: t('placeholders.password') %>
         </div>
 
         <div class="form-control mt-5">
           <%= f.label :password_confirmation, class: 'label-text text-xl' %>
-          <%= f.password_field :password_confirmation, autocomplete: "new-password", class: 'input input-warning border-gray-800 border-opacity-50 bg-yellow-50', placeholder: '確認用でもう一度入力ください' %>
+          <%= f.password_field :password_confirmation, autocomplete: "new-password", class: 'input input-warning border-gray-800 border-opacity-50 bg-yellow-50', placeholder: t('placeholders.password_confirmation') %>
         </div>
 
         <div class="actions">
-          <%= f.submit "新規登録", class: 'btn btn-wide btn-neutral w-full mt-10' %>
+          <%= f.submit t('.sign_up'), class: 'btn btn-wide btn-neutral w-full mt-10' %>
         </div>
       <% end %>
     </div>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,18 +1,18 @@
 <div class="container mx-auto mb-20">
   <div class="px-5 border-opacity-50">
     <div class="grid place-items-center">
-      <h2 class="place-items-centeer my-6 text-2xl text-bold">ログイン</h2>
+      <h2 class="place-items-centeer my-6 text-2xl text-bold"><%= t('.sign_in') %></h2>
     </div>
     <div class="grid place-items-center">     
       <%= form_with model: resource, url: session_path(resource_name), class: 'w-full px-5 md:w-3/5 md:px-0', local: true do |f| %>
         <div class="form-control">
           <%= f.label :email, class: 'label-text text-xl' %>
-          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'input input-warning border-gray-800 border-opacity-50 bg-yellow-50', placeholder: 'sample@samplecom' %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'input input-warning border-gray-800 border-opacity-50 bg-yellow-50', placeholder: t('placeholders.email') %>
         </div>
 
         <div class="form-control mt-5">
           <%= f.label :password, class: 'text-label text-xl' %>
-          <%= f.password_field :password, autocomplete: "current-password", class: 'input input-warning border-gray-800 border-opacity-50 bg-yellow-50', placeholder: 'パスワード（6文字以上）' %>
+          <%= f.password_field :password, autocomplete: "current-password", class: 'input input-warning border-gray-800 border-opacity-50 bg-yellow-50', placeholder: t('placeholders.password') %>
         </div>
 
         <% if devise_mapping.rememberable? %>
@@ -23,7 +23,7 @@
         <% end %>
 
         <div class="actions">
-          <%= f.submit "ログイン", class: 'btn btn-wide btn-neutral w-full mt-10' %>
+          <%= f.submit t('.sign_in'), class: 'btn btn-wide btn-neutral w-full mt-10' %>
         </div>
       <% end %>
     </div>

--- a/app/views/users/shared/_links.html.erb
+++ b/app/views/users/shared/_links.html.erb
@@ -1,25 +1,25 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "アカウントをお持ちの方はこちら", new_session_path(resource_name), class: 'link link-neutral' %><br />
+  <%= link_to t(".sign_in"), new_session_path(resource_name), class: 'link link-neutral' %><br />
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "アカウントをお持ちでない方はこちら", new_registration_path(resource_name), class: 'link link-neutral'  %><br />
+  <%= link_to t(".sign_up"), new_registration_path(resource_name), class: 'link link-neutral' %><br />
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "パスワードを忘れた方はこちら", new_password_path(resource_name), class: 'link link-neutral'  %><br />
+  <%= link_to t(".forgot_your_password"), new_password_path(resource_name), class: 'link link-neutral' %><br />
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
+  <%= link_to t('.didn_t_receive_confirmation_instructions'), new_confirmation_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
+  <%= link_to t('.didn_t_receive_unlock_instructions'), new_unlock_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), data: { turbo: false } %><br />
+    <%= button_to t('.sign_in_with_provider', provider: OmniAuth::Utils.camelize(provider)), omniauth_authorize_path(resource_name, provider), data: { turbo: false } %><br />
   <% end %>
 <% end %>

--- a/app/views/users/unlocks/new.html.erb
+++ b/app/views/users/unlocks/new.html.erb
@@ -1,4 +1,4 @@
-<h2>Resend unlock instructions</h2>
+<h2><%= t('.resend_unlock_instructions') %></h2>
 
 <%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
   <%= render "users/shared/error_messages", resource: resource %>
@@ -9,7 +9,7 @@
   </div>
 
   <div class="actions">
-    <%= f.submit "Resend unlock instructions" %>
+    <%= f.submit t('.resend_unlock_instructions') %>
   </div>
 <% end %>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,5 +33,13 @@ module FukuCafe
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    # localization
+    config.i18n.default_locale = :ja
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
+
+    # time_zone
+    config.time_zone = 'Tokyo'
+    config.active_record.default_timezone = :local
   end
 end

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -1,0 +1,2 @@
+ja:
+  activerecord:

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -1,0 +1,150 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        confirmation_sent_at: パスワード確認送信時刻
+        confirmation_token: パスワード確認用トークン
+        confirmed_at: パスワード確認時刻
+        created_at: 作成日
+        current_password: 現在のパスワード
+        current_sign_in_at: 現在のログイン時刻
+        current_sign_in_ip: 現在のログインIPアドレス
+        email: メールアドレス
+        encrypted_password: 暗号化パスワード
+        failed_attempts: 失敗したログイン試行回数
+        last_sign_in_at: 最終ログイン時刻
+        last_sign_in_ip: 最終ログインIPアドレス
+        locked_at: ロック時刻
+        password: パスワード
+        password_confirmation: パスワード（確認用）
+        remember_created_at: ログイン記憶時刻
+        remember_me: ログインを記憶する
+        reset_password_sent_at: パスワードリセット送信時刻
+        reset_password_token: パスワードリセット用トークン
+        sign_in_count: ログイン回数
+        unconfirmed_email: 未確認Eメール
+        unlock_token: ロック解除用トークン
+        updated_at: 更新日
+        name: '名前'
+    models:
+      user: ユーザー
+  users:
+    confirmations:
+      confirmed: メールアドレスが確認できました。
+      new:
+        resend_confirmation_instructions: アカウント確認メール再送
+      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
+    failure:
+      already_authenticated: すでにログインしています。
+      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
+      invalid: "%{authentication_keys}またはパスワードが違います。"
+      last_attempt: もう一回誤るとアカウントがロックされます。
+      locked: アカウントはロックされています。
+      not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
+      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
+      unauthenticated: ログインもしくはアカウント登録してください。
+      unconfirmed: メールアドレスの本人確認が必要です。
+    mailer:
+      confirmation_instructions:
+        action: メールアドレスの確認
+        greeting: "%{recipient}様"
+        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
+        subject: メールアドレス確認メール
+      email_changed:
+        greeting: こんにちは、%{recipient}様。
+        message: メールアドレスの（%{email}）変更が完了したため、メールを送信しています。
+        message_unconfirmed: メールアドレスが（%{email}）変更されたため、メールを送信しています。
+        subject: メール変更完了
+      password_change:
+        greeting: "%{recipient}様"
+        message: パスワードが再設定されました。
+        subject: パスワードの変更について
+      reset_password_instructions:
+        action: パスワード変更
+        greeting: "%{recipient}様"
+        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
+        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
+        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
+        subject: パスワードの再設定について
+      unlock_instructions:
+        action: アカウントのロック解除
+        greeting: "%{recipient}様"
+        instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
+        message: ログイン失敗が繰り返されたため、アカウントはロックされています。
+        subject: アカウントのロック解除について
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      edit:
+        change_my_password: パスワードを変更する
+        change_your_password: パスワードを変更
+        confirm_new_password: 確認用新しいパスワード
+        new_password: 新しいパスワード
+      new:
+        sent: '送信'
+        forgot_your_password: パスワードを忘れましたか？
+        send_me_reset_password_instructions: パスワードの再設定方法を送信する
+      no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
+      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
+      updated: パスワードが正しく変更されました。
+      updated_not_active: パスワードが正しく変更されました。
+    registrations:
+      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
+      edit:
+        are_you_sure: 本当によろしいですか？
+        cancel_my_account: アカウント削除
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
+        title: "%{resource}編集"
+        unhappy: 気に入りません
+        update: 更新
+        we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
+      new:
+        sign_up: アカウント登録
+      signed_up: アカウント登録が完了しました。
+      signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
+      signed_up_but_locked: アカウントがロックされているためログインできません。
+      signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
+      update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
+      updated: アカウント情報を変更しました。
+      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
+    sessions:
+      already_signed_out: 既にログアウト済みです。
+      new:
+        sign_in: ログイン
+      signed_in: ログインしました。
+      signed_out: ログアウトしました。
+    shared:
+      links:
+        back: 戻る
+        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか？
+        didn_t_receive_unlock_instructions: アカウントのロック解除方法のメールを受け取っていませんか？
+        forgot_your_password: パスワードを忘れましたか？
+        sign_in: ログイン
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: アカウント登録
+      minimum_password_length: "（%{count}字以上）"
+    unlocks:
+      new:
+        resend_unlock_instructions: アカウントのロック解除方法を再送する
+      send_instructions: アカウントのロック解除方法を数分以内にメールでご連絡します。
+      send_paranoid_instructions: アカウントが見つかった場合、アカウントのロック解除方法を数分以内にメールでご連絡します。
+      unlocked: アカウントをロック解除しました。
+  errors:
+    messages:
+      already_confirmed: は既に登録済みです。ログインしてください。
+      confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
+      expired: の有効期限が切れました。新しくリクエストしてください。
+      not_found: は見つかりませんでした。
+      not_locked: はロックされていません。
+      not_saved:
+        one: エラーが発生したため %{resource} は保存されませんでした。
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"
+  placeholders:
+    name: '○文字以上で入力してください'
+    email: 'fukucafe@example.com'
+    password: 'パスワード（6文字以上）'
+    password_confirmation: '確認用でもう一度入力してください'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,0 +1,15 @@
+ja:
+  defaults:
+    sign_up:  'アカウント登録'
+    sign_in: 'ログイン'
+    sign_out: 'ログアウト'
+    privacy_policy: 'プライバシーポリシー'
+    terms: '利用規約'
+    home: 'ホーム'
+    mypage: 'マイページ'
+    search_map: 'マップから検索'
+    search_shop: 'セレクトショップから検索'
+    search_cafe: 'カフェから検索'
+    search_brand: 'ブランドから検索'
+    saved: '保存済み'
+


### PR DESCRIPTION
## 内容
・gem 'devise-i18n'を追加して、devise.views.ja.ymlファイルを追加しました。
・devise以外の部分を翻訳するために、ja.ymlファイルをActiveRecord用（今後使用していく）とビューファイル用に分けて追加しました。

## 確認内容
・すでに作成していた、トップページ、ヘッダー・フッター、ユーザー登録・ログイン・パスワードリセット申請画面、に翻訳ファイルが適用されていることを確認しました。

## 確認結果
「トップページ」
![image](https://github.com/jinta-shimo02/fuku_cafe/assets/100778581/e06d2f93-c8a7-4756-aa0e-fe215bfac4f5)

「フッター」
![image](https://github.com/jinta-shimo02/fuku_cafe/assets/100778581/f850f1ee-a510-4d18-a96b-e8abb1b7a66a)

「アカウント登録画面」
![image](https://github.com/jinta-shimo02/fuku_cafe/assets/100778581/4a647ee8-59db-4617-b50b-9f0948e1e31c)

「ログイン画面」
![image](https://github.com/jinta-shimo02/fuku_cafe/assets/100778581/22ab1423-93c7-4ca5-bef2-e80a4863eb96)

「パスワードリセット申請画面」
![image](https://github.com/jinta-shimo02/fuku_cafe/assets/100778581/88756d8f-5dbe-4f48-8f9c-6abf5ce99d45)
