### PR TITLE
マイページ作成、プロフィール編集

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :authenticate_user!
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name])

--- a/app/controllers/my_pages_controller.rb
+++ b/app/controllers/my_pages_controller.rb
@@ -1,0 +1,25 @@
+class MyPagesController < ApplicationController
+  before_action :set_user, only: %i[show edit update]
+
+  def show; end
+  
+  def edit; end
+
+  def update
+    if @user.update(user_params)
+      redirect_to my_page_path, notice: t('defaults.message.updated')
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  def set_user
+    @user = User.find(current_user.id)
+  end
+  
+  def user_params
+    params.require(:user).permit(:name, :email)
+  end
+end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,4 +1,5 @@
 class StaticPagesController < ApplicationController
+  skip_before_action :authenticate_user!
   def top; end
 
   def terms; end

--- a/app/helpers/my_pages_helper.rb
+++ b/app/helpers/my_pages_helper.rb
@@ -1,0 +1,2 @@
+module MyPagesHelper
+end

--- a/app/views/my_pages/edit.html.erb
+++ b/app/views/my_pages/edit.html.erb
@@ -1,0 +1,22 @@
+<div class="container mx-auto mb-20">
+  <div class="px-5 border-opacity-50">
+    <div class="grid place-items-center">
+      <h2 class="place-items-centeer my-6 text-2xl text-bold"><%= t('defaults.profile_edit') %></h2>
+    </div>
+    <div class="grid place-items-center">
+      <%= form_with model: @user, url: my_page_path, method: :patch, class: 'w-full px-5 md:w-3/5 md:px-0', local: true do |f| %>
+        <div class="form-control">
+          <%= f.label :name, class: 'label-text text-xl' %>
+          <%= f.text_field :name, class: 'input input-warning border-gray-800 border-opacity-50 bg-yellow-50' %>
+        </div>
+        <div class="form-control mt-5">
+          <%= f.label :email, class: 'label-text text-xl' %>
+          <%= f.email_field :email, class: 'input input-warning border-gray-800 border-opacity-50 bg-yellow-50' %>
+        </div>
+        <div class="actions">
+          <%= f.submit class: 'btn btn-wide btn-neutral w-full mt-10' %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/my_pages/show.html.erb
+++ b/app/views/my_pages/show.html.erb
@@ -1,0 +1,47 @@
+<div class="grid place-items-center mb-20">
+  <h1 class="text-3xl m-10"><%= t('defaults.my_page') %></h1>
+  <div class="card w-4/5 bg-base-100 shadow-md z-0">
+    <div class="card-body border-b border-gray-500 p-10">
+      <div class="flex justify-evenly items-center">
+        <%= image_tag 'logo.png', class: 'w-48 h-48' %>
+        <div class="flex flex-col">
+          <p class="mb-10 text-center"><%= @user.name %></p>
+          <%= link_to '編集', edit_my_page_path, class: 'btn btn-neutral' %>
+        </div>
+      </div>
+    </div>
+    <div class="card-body border-b border-gray-500 p-10">
+      <div class="flex justify-center items-center h-full">
+        <div class="card w-11/12 bg-base-200 border-gray-500 shadow-xl">
+          <div class="border-b border-gray-500 p-5">
+            <h2 class="text-xl">マイリスト</h3>
+          </div>
+          <div class="card-body p-5">
+            <p class="text-left border-b border-gray-500 p-3">リスト一覧</p>
+            <p class="text-left border-b border-gray-500 p-3">リスト一覧</p>
+            <p class="text-left border-b border-gray-500 p-3">リスト一覧</p>
+            <p class="text-left border-b border-gray-500 p-3">リスト一覧</p>
+            <p class="text-left border-b border-gray-500 p-3">リスト一覧</p>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="card-body p-10">
+      <div class="flex flex-col justify-center items-center h-full">
+        <h2 class="text-left text-xl border-b border-gray-500 w-11/12 p-5">レビューしたショップ</h2>
+        <div class="card w-11/12 bg-base-200 border-gray-500 shadow-md m-2">
+          <p class="p-7">ショップ情報</p>
+        </div>
+        <div class="card w-11/12 bg-base-200 border-gray-500 shadow-md m-2">
+          <p class="p-7">ショップ情報</p>
+        </div>
+        <div class="card w-11/12 bg-base-200 border-gray-500 shadow-md m-2">
+          <p class="p-7">ショップ情報</p>
+        </div>
+        <div class="card w-11/12 bg-base-200 border-gray-500 shadow-md m-2">
+          <p class="p-7">ショップ情報</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -15,11 +15,11 @@
     <label for="my-drawer-4" class="drawer-button">
       <i class="fas fa-bars mr-5 h-5 w-5"></i>
     </label>
-    <div class="drawer-side">
+    <div class="drawer-side z-10">
       <label for="my-drawer-4" class="drawer-overlay"></label>
       <ul class="menu p-4 w-80 h-full bg-yellow-50 text-base-content">
         <%= link_to t('defaults.home'), '#', class: 'mt-10 text-sm border-b border-gray-500 pb-2' %>
-        <%= link_to t('defaults.mypage'), '#', class: 'mt-10 text-sm border-b border-gray-500 pb-2' %>
+        <%= link_to t('defaults.mypage'), my_page_path, class: 'mt-10 text-sm border-b border-gray-500 pb-2' %>
         <%= link_to t('defaults.search_shop'), '#', class: 'mt-10 text-sm border-b border-gray-500 pb-2' %>
         <%= link_to t('defaults.search_cafe'), '#', class: 'mt-10 text-sm border-b border-gray-500 pb-2' %>
         <%= link_to t('defaults.search_brand'), '#', class: 'mt-10 text-sm border-b border-gray-500 pb-2' %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -12,4 +12,9 @@ ja:
     search_cafe: 'カフェから検索'
     search_brand: 'ブランドから検索'
     saved: '保存済み'
+    my_page: 'マイページ'
+    profile_edit: 'プロフィール編集'
+
+    message:
+      updated: '更新しました'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,5 @@ Rails.application.routes.draw do
   root to: 'static_pages#top'
   get 'terms', to: 'static_pages#terms'
   get 'privacy_policy', to: 'static_pages#privacy_policy'
+  resource :my_page, only: %i[show edit update]
 end


### PR DESCRIPTION
## 内容
・マイページを作成しました。
・プロフィール編集機能を実装しました。（マイページから編集できます。）

## 確認内容
・マイページは、プロフィール・マイリスト一覧（仮）、レビューしたショップ一覧（仮）でが表示されることを想定してレイアウトしました。
・マイページはログインしていないと、見ることができないことを確認しました。
・プロフィール編集機能は、編集画面から編集して、更新されることを確認しました。

## 確認結果
https://github.com/jinta-shimo02/fuku_cafe/assets/100778581/9a972a6e-043b-48d8-9b35-5132f7b93f26


https://github.com/jinta-shimo02/fuku_cafe/assets/100778581/5e06b2bb-c820-4f14-a936-4979a9f60d90


