### PR TITLE
ショップの詳細画面を作成

### DIFF
--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -1,0 +1,4 @@
+class ShopsController < ApplicationController
+  def show
+  end
+end

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -1,4 +1,6 @@
 class ShopsController < ApplicationController
   def show
+    @shop = Shop.find(params[:id])
+    @shop_images = @shop.shop_images
   end
 end

--- a/app/helpers/shops_helper.rb
+++ b/app/helpers/shops_helper.rb
@@ -1,0 +1,2 @@
+module ShopsHelper
+end

--- a/app/javascript/google_maps.js
+++ b/app/javascript/google_maps.js
@@ -99,7 +99,7 @@ window.initMap = function() {
               <img src="https://maps.googleapis.com/maps/api/place/photo?maxwidth=200&photo_reference=${clothes_image.image}&key=${API_KEY}" class="p-5 w-48 h-48 rounded-3xl">
               <div class="flex-col">
                 <ul>
-                  <li class="pl-6 pt-6 text-3xl underline">${shop.name}</li>
+                  <li class="pl-6 pt-6 text-3xl underline"><a href="/shops/${shop.id}">${shop.name}</a></li>
                   <li class="pl-6 pt-4">${shop.address}</li>
                   <li class="pl-6 pt-1.5">${shop.phone_number}</li>
                 </ul>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -18,7 +18,7 @@
     <div class="drawer-side z-10">
       <label for="my-drawer-4" class="drawer-overlay"></label>
       <ul class="menu p-4 w-80 h-full bg-yellow-50 text-base-content">
-        <%= link_to t('defaults.home'), '#', class: 'mt-10 text-sm border-b border-gray-500 pb-2' %>
+        <%= link_to t('defaults.home'), home_path, class: 'mt-10 text-sm border-b border-gray-500 pb-2' %>
         <%= link_to t('defaults.mypage'), my_page_path, class: 'mt-10 text-sm border-b border-gray-500 pb-2' %>
         <%= link_to t('defaults.search_shop'), '#', class: 'mt-10 text-sm border-b border-gray-500 pb-2' %>
         <%= link_to t('defaults.search_cafe'), '#', class: 'mt-10 text-sm border-b border-gray-500 pb-2' %>

--- a/app/views/shops/show.html.erb
+++ b/app/views/shops/show.html.erb
@@ -1,0 +1,46 @@
+<div class="grid place-items-center">
+  <div class="card w-4/5 bg-base-100 shadow-md z-0 rounded-3xl my-20">
+    <div class="card-body pt-20">
+      <h1 class="text-2xl underline pl-10"><%= @shop.name %></h1>
+      <p class="pl-20 mt-4 text-lg">住　　所：<%= @shop.address %></p>
+      <div class="flex flex-wrap">
+        <p class="pl-20 mt-4 text-lg">営業時間：
+          <p class="mt-4 text-lg">
+            <%= raw @shop.opening_hours.gsub("\n", '<br>') %>
+          </p>
+        </p>
+      </div>
+      <p class="pl-20 mt-4 text-lg">公式サイト：<span class="text-blue-500"><%= link_to "#{@shop.web_site.chomp('/')}", @shop.web_site.chomp('/') %></span></p>
+      <p class="pl-20 mt-4 text-lg">電話番号：<%= @shop.phone_number %></p>
+      <p class="pl-20 mt-4 text-lg">取扱ブランド</p>
+      <p class="text-lg text-center">Daiwa Pier39　YOKE　COMOLI　AURALEE　Captain sunshine　until　</p>
+      <p class="text-lg text-center">Daiwa Pier39　YOKE　COMOLI　AURALEE　Captain sunshine　until　</p>
+      <p class="pl-20 mt-4 text-lg">ギャラリー</p>
+      <div class="flex pl-10">
+        <% @shop_images.each do |shop_image| %>
+          <img src="https://maps.googleapis.com/maps/api/place/photo?maxheight=150&maxwidth=150&photo_reference=<%= shop_image.image %>&key=<%= ENV['API_KEY'] %>" class="mx-2">
+        <% end %>
+      </div>
+    </div>
+    <div class="card-body border-t border-gray-500 p-10">
+      <div class="flex justify-center items-center h-full">
+        <div class="card w-11/12 bg-base-200 shadow-xl">
+          <p class="pl-10 py-10 text-lg">レビュー</p>
+          <div class="flex">
+              <p class="text-sm text-center">まだ機能していません</p>
+          </div>
+          <div class="flex justify-end mx-10 mt-10 mb-5">
+            <%= link_to 'レビューを書く', '#', class: 'btn btn-neutral w-48 h-10 ' %>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="card-body border-t border-gray-500 p-10">
+      <div class="flex justify-center items-center h-full">
+        <div class="card w-11/12 bg-base-200 shadow-xl">
+          <p class="pl-10 py-10 text-ls">近くのおすすめカフェ</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -9,7 +9,7 @@
         あなた好みのお店はきっとそこにある
       </p>
       <div class="mt-32 flex">
-        <%= link_to t('defaults.search_map'), '#', class: 'bg-orange-300 py-4 px-16 rounded-xl mr-10 text-xl' %>
+        <%= link_to t('defaults.search_map'), home_path, class: 'bg-orange-300 py-4 px-16 rounded-xl mr-10 text-xl' %>
         <%= link_to t('defaults.sign_up'), new_user_registration_path, class: 'bg-gray-300 py-4 px-16 rounded-xl text-xl' %>
       </div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,11 @@
 Rails.application.routes.draw do
   mount RailsAdmin::Engine => '/admin', as: 'rails_admin'
-  devise_for :users
   root to: 'static_pages#top'
   get 'terms', to: 'static_pages#terms'
   get 'privacy_policy', to: 'static_pages#privacy_policy'
-  resource :my_page, only: %i[show edit update]
   get 'home', to: 'maps#home'
+  devise_for :users
+  resource :my_page, only: %i[show edit update]
   match 'search', to: 'maps#search', via: [:get]
+  resources :shops, only: %i[show]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,8 +4,8 @@ Rails.application.routes.draw do
   get 'terms', to: 'static_pages#terms'
   get 'privacy_policy', to: 'static_pages#privacy_policy'
   get 'home', to: 'maps#home'
+  match 'search', to: 'maps#search', via: [:get]
   devise_for :users
   resource :my_page, only: %i[show edit update]
-  match 'search', to: 'maps#search', via: [:get]
   resources :shops, only: %i[show]
 end

--- a/spec/helpers/shops_helper_spec.rb
+++ b/spec/helpers/shops_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the ShopsHelper. For example:
+#
+# describe ShopsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe ShopsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/shops_spec.rb
+++ b/spec/requests/shops_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe "Shops", type: :request do
+  describe "GET /show" do
+    it "returns http success" do
+      get "/shops/show"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/views/shops/show.html.erb_spec.rb
+++ b/spec/views/shops/show.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "shops/show.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 内容
- ショップの詳細画面を作成（土台）しました。
- マップ検索で表示されたショップ一覧のショップ名をクリックすると、詳細画面に飛ぶようにリンクの修正をしました。

## 確認事項
- ショップ一覧のショップ名をクリックすると、詳細画面へ飛ぶ

## 確認結果
![84d5bf232cc2c26992f4c8c6cdf0f886](https://github.com/jinta-shimo02/fuku_cafe/assets/100778581/b557cd0c-0998-4dd2-bfd6-993d89a8c87e)

