### PR TITLE
brandsテーブル、shop_brandsテーブルの作成

### DIFF
--- a/app/models/brand.rb
+++ b/app/models/brand.rb
@@ -1,0 +1,2 @@
+class Brand < ApplicationRecord
+end

--- a/app/models/brand.rb
+++ b/app/models/brand.rb
@@ -1,2 +1,4 @@
 class Brand < ApplicationRecord
+  has_many :shop_brands
+  has_many :shops, through: :shop_brands
 end

--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -1,5 +1,7 @@
 class Shop < ApplicationRecord
   has_many :shop_images, dependent: :destroy
+  has_many :shop_brands
+  has_manu :brands, through: :shop_brands
 
   validates :name, presence: true
   validates :latitude, presence: true

--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -1,7 +1,7 @@
 class Shop < ApplicationRecord
   has_many :shop_images, dependent: :destroy
   has_many :shop_brands
-  has_manu :brands, through: :shop_brands
+  has_many :brands, through: :shop_brands
 
   validates :name, presence: true
   validates :latitude, presence: true

--- a/app/models/shop_brand.rb
+++ b/app/models/shop_brand.rb
@@ -1,2 +1,4 @@
 class ShopBrand < ApplicationRecord
+  belongs_to :shop
+  belongs_to :brand
 end

--- a/app/models/shop_brand.rb
+++ b/app/models/shop_brand.rb
@@ -1,0 +1,2 @@
+class ShopBrand < ApplicationRecord
+end

--- a/db/migrate/20230902054947_create_brands.rb
+++ b/db/migrate/20230902054947_create_brands.rb
@@ -1,0 +1,9 @@
+class CreateBrands < ActiveRecord::Migration[7.0]
+  def change
+    create_table :brands do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230902061414_create_shop_brands.rb
+++ b/db/migrate/20230902061414_create_shop_brands.rb
@@ -1,0 +1,12 @@
+class CreateShopBrands < ActiveRecord::Migration[7.0]
+  def change
+    create_table :shop_brands do |t|
+      t.references :shop, foreign_key: true
+      t.references :brand, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :shop_brands, [:shop_id, :brand_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_11_042054) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_02_054947) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "brands", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "shop_images", force: :cascade do |t|
     t.string "image"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_02_054947) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_02_061414) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -18,6 +18,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_02_054947) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "shop_brands", force: :cascade do |t|
+    t.bigint "shop_id"
+    t.bigint "brand_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["brand_id"], name: "index_shop_brands_on_brand_id"
+    t.index ["shop_id", "brand_id"], name: "index_shop_brands_on_shop_id_and_brand_id", unique: true
+    t.index ["shop_id"], name: "index_shop_brands_on_shop_id"
   end
 
   create_table "shop_images", force: :cascade do |t|
@@ -57,5 +67,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_02_054947) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "shop_brands", "brands"
+  add_foreign_key "shop_brands", "shops"
   add_foreign_key "shop_images", "shops"
 end

--- a/lib/brands.csv
+++ b/lib/brands.csv
@@ -1,0 +1,90 @@
+ブランド名
+AURALEE
+A.PRESSE
+Arnold Palmer by ALWAYTH
+ANCOR
+ARC’TERYX
+ASICS
+AFTERHOURS
+ATON
+blurhms
+blurhms ROOTSTOCK
+BAICYCLON by bagiack
+BONEE
+BIOTOP original
+BIRKENSTOCK
+COMOLI
+CINOH
+Cristaseya
+C.P.COMPANY
+COMME des CARCONS HOMME
+COMME des CARCONS HOMME PLUS
+CITY COUNTRY CITY
+CALMANTHOLOGY
+CAMIEL FORTGENS
+Clarks
+coupronde
+CASEY CASEY
+C.E
+CABaN
+DIGAWEL  
+DESENDANT   
+DAIWA PIER39    
+DAIWA LIFE STYLE    
+DANTON    
+Engineerd Garments
+EVCON
+FARAH    
+FITFOR    
+FRANK LEDER
+Graphpaper    
+Gymphlex    
+Hender Scheme    
+HYKE    
+HERILL    
+HOKA
+is-ness    
+INTERIM    
+IRENISA
+JIL SANDER    
+KAPTAIN SUNSHINE    
+KEEN    
+KHOKI
+L’ECHOPPE
+marka
+MY___
+mfpen
+MAATEE&SONS
+Maison Margiela
+MARROW    
+MM6
+New Balance    
+On    
+OUTIL    
+ORCIVAL    
+OAMC      
+PHEENY    
+REPRODUCTION OF FOUND    
+RIER    
+ROTOL    
+REEBOK
+SALOMON    
+stein    
+STUDIO NICHOLSON    
+SEDAN ALL-PURPOSE    
+Taiga Takahashi    
+THE RERACS    
+The Inoue Brothers    
+THE SHINZONE
+UNIVERSAL_PRODUCTS.    
+UNUSED    
+URU    
+unfil    
+VISVIM    
+VAGUE WATCH Co.
+WACOMARIA
+XOLO JEWELRY    
+YAECA    
+YOKE
+1LDK Stand
++81

--- a/lib/tasks/save_brands.rake
+++ b/lib/tasks/save_brands.rake
@@ -1,0 +1,25 @@
+require 'csv'
+
+csv_file = 'lib/brands.csv'
+
+namespace :brands do
+  desc 'save brands'
+  task save_to_table: :environment do
+    CSV.foreach(csv_file, headers: true) do |row|
+      brand_name = row['ブランド名']
+
+      unless Brand.exists?(name: brand_name)
+        brand = Brand.new(name: brand_name)
+
+        if brand.save
+          puts "ブランド：#{brand_name}を保存しました。"
+        else
+          puts "ブランド：#{brand_name}の保存に失敗しました。"
+          puts "#{brand.errors.full_messages}"
+        end
+      else
+        puts "ブランド：#{brand_name}は既に保存されています。"
+      end
+    end
+  end
+end

--- a/spec/factories/brands.rb
+++ b/spec/factories/brands.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :brand do
+    
+  end
+end

--- a/spec/factories/shop_brands.rb
+++ b/spec/factories/shop_brands.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :shop_brand do
+    
+  end
+end

--- a/spec/models/brand_spec.rb
+++ b/spec/models/brand_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Brand, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/shop_brand_spec.rb
+++ b/spec/models/shop_brand_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ShopBrand, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 内容
- brandsテーブルと、shop_brandsテーブル（shopsテーブルとbrandsテーブルの中間テーブル）を作成し、関連付けを行いました。
- brandsテーブルには、rakeタスクで保存したいブランド名を一括で保存しました。
- shopsテーブルとbrandsテーブルの関連付けは管理画面で手動で行いました。

## 確認事項
- rakeタスクを実行し、brandsテーブルに値が保存されていることを確認。
- shopsテーブルとbrandsテーブルの関連付けを管理画面で行い、コンソールから関連付けが行われていることを確認。

## 確認結果
- 「rakeタスク実行画面」
![](https://i.gyazo.com/1e77bb36a117bc9b88316a1aafc1b020.png)
- 「ブランドが保存されているか管理画面で確認」
![](https://i.gyazo.com/8dead866f588374fae074fc15cb2e49e.png)
- 「ブランドとショップが関連付けされていることを管理画面で確認」
![](https://i.gyazo.com/40978c00d98fe4ee02e82d3f2c6e2bd0.png)
- 「ブランドとショップが関連付けされていることをコンソールから確認」
![](https://i.gyazo.com/3afe88b70189724460c76af0b49d481c.png)

