### PR TITLE
フラッシュメッセージの修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,12 @@
 class ApplicationController < ActionController::Base
+  add_flash_types :success, :info, :warning, :danger
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :authenticate_user!
   before_action :set_brands
+
+  def after_sign_in_path_for(resource)
+    home_path
+  end
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name])

--- a/app/controllers/list_shops_controller.rb
+++ b/app/controllers/list_shops_controller.rb
@@ -7,7 +7,7 @@ class ListShopsController < ApplicationController
     if @list_shop.save
       render json: { success: true, name: @list_shop.shop_saved_list.name }
     else
-      render json: { sucess: false, errors: @list_shop.errors.full_messages }
+      render json: { success: false, errors: @list_shop.errors.full_messages }
     end
   end
   

--- a/app/controllers/my_pages_controller.rb
+++ b/app/controllers/my_pages_controller.rb
@@ -7,8 +7,9 @@ class MyPagesController < ApplicationController
 
   def update
     if @user.update(user_params)
-      redirect_to my_page_path, notice: t('defaults.message.updated')
+      redirect_to my_page_path, success: t('defaults.message.updated')
     else
+      flash.now[:danger] = t('defaults.message.update_failed')
       render :edit
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,15 +2,11 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable
+         :recoverable, :rememberable, :validatable
 
   has_many :shop_saved_lists, dependent: :destroy
          
   enum role: { general: 0, admin: 1 }
 
   validates :name, presence: true, length: { maximum: 255 }
-  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
-  validates :email, presence: true, format: { with: VALID_EMAIL_REGEX }, uniqueness: { case_sensitive: false } 
-  validates :password, presence: true, length: { minimum: 6 }
-  validates :password_confirmation, presence: true
 end

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,3 +1,11 @@
 <% flash.each do |key, value| %>
-  <%= content_tag :div, value, class: "flash flash_#{key}" %>
+  <% if key == 'success' || key == 'notice' %>
+    <div class="flex items-center bg-green-400 text-white text-sm font-bold pl-10 py-5" role="alert"><%= value %></div>
+  <% elsif key == 'info' %>
+    <div class="flex items-center bg-blue-400 text-white text-sm font-bold pl-10 py-5" role="alert"><%= value %></div>
+  <% elsif key == 'warning' %>
+    <div class="flex items-center bg-yellow-400 text-white text-sm font-bold pl-10 py-5" role="alert"><%= value %></div>
+  <% elsif key == 'danger' %>
+    <div class="flex items-center bg-red-400 text-white text-sm font-bold pl-10 py-5" role="alert"><%= value %></div>
+  <% end %>
 <% end %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -17,4 +17,5 @@ ja:
 
     message:
       updated: '更新しました'
+      update_failed: '更新に失敗しました'
 


### PR DESCRIPTION
## 内容
- フラッシュメッセージ表示を修正しました。

## 確認事項
- 新規登録後の表示
- ログイン後の表示
- ログアウト後の表示
- マイページ更新後の表示

## 確認結果
「新規登録後の表示」
![](https://i.gyazo.com/3887d8c54b069abd4008d4054e9bbffc.png)

「ログイン後の表示」
![](https://i.gyazo.com/d067a231859a00c9ae47ab34e5828946.png)

「ログアウト後の表示」
![](https://i.gyazo.com/fa9ab4498c82d529188cbf8ee71e0636.png)

「マイページ更新後の表示」
![](https://i.gyazo.com/eee06ea5e1b671e812f53dcf1702d610.png)
