### PR TITLE
マップ検索動作の修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,6 +75,9 @@ gem 'gon'
 # debug
 gem 'pry-rails'
 
+# Geolocation
+gem 'geokit-rails'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,10 @@ GEM
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
     ffi (1.15.5)
+    geokit (1.14.0)
+    geokit-rails (2.5.0)
+      geokit (~> 1.5)
+      rails (>= 3.0)
     globalid (1.1.0)
       activesupport (>= 5.0)
     gon (6.4.0)
@@ -353,6 +357,7 @@ DEPENDENCIES
   dotenv-rails
   enum_help
   factory_bot_rails
+  geokit-rails
   gon
   google_places
   jbuilder

--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -7,26 +7,23 @@ class MapsController < ApplicationController
     gon.api_key = ENV['API_KEY']
     gon.user_logged_in = user_signed_in?
 
-    north = params[:north].to_f
-    south = params[:south].to_f
-    east = params[:east].to_f
-    west = params[:west].to_f
-
+    latitude = params[:latitude].to_f
+    longitude = params[:longitude].to_f
     
     is_clothes_filter = params[:is_clothes_filter] == 'true'
     is_cafe_filter = params[:is_cafe_filter] == 'true'
     
     if params[:is_clothes_filter] == 'true'
-      @clothes = Clothes.includes(:shop_images).where(latitude: south..north, longitude: west..east)
+      @clothes = Clothes.includes(:shop_images).within(1, origin: [latitude, longitude]).by_distance(origin: [latitude, longitude])
     elsif params[:is_cafe_filter] == 'true'
-      @cafes = Cafe.includes(:shop_images).where(latitude: south..north, longitude: west..east)
+      @cafes = Cafe.includes(:shop_images).within(1, origin: [latitude, longitude]).by_distance(origin: [latitude, longitude])
     elsif params[:brand_name]
       brand = Brand.find_by(name: params[:brand_name])
       brand_shops = brand.shops
-      @clothes = brand_shops.includes(:shop_images).where(latitude: south..north, longitude: west..east)
+      @clothes = brand_shops.includes(:shop_images).within(1, origin: [latitude, longitude]).by_distance(origin: [latitude, longitude])
     else
-      @clothes = Clothes.includes(:shop_images).where(latitude: south..north, longitude: west..east)
-      @cafes = Cafe.includes(:shop_images).where(latitude: south..north, longitude: west..east)
+      @clothes = Clothes.includes(:shop_images).within(1, origin: [latitude, longitude]).by_distance(origin: [latitude, longitude])
+      @cafes = Cafe.includes(:shop_images).within(1, origin: [latitude, longitude]).by_distance(origin: [latitude, longitude])
     end
 
 

--- a/app/javascript/google_maps.js
+++ b/app/javascript/google_maps.js
@@ -99,11 +99,9 @@ function updateSearch() {
 function filterSearch(filterType, brandName) {
   var circleCenter = circle.getCenter();
   var radius = circle.getRadius();
-  var circleBounds = {
-    north: circleCenter.lat() + radius / 111111,
-    south: circleCenter.lat() - radius / 111111,
-    east: circleCenter.lng() + radius / (111111 * Math.cos(circleCenter.lat() * Math.PI / 180)),
-    west: circleCenter.lng() - radius / (111111 * Math.cos(circleCenter.lat() * Math.PI / 180))
+  var circleLatLng = {
+    latitude: circleCenter.lat(),
+    longitude: circleCenter.lng()
   };
 
   var filterParam = '';
@@ -116,7 +114,7 @@ function filterSearch(filterType, brandName) {
     filterParam = 'brand_name=' + brandName;
   } 
 
-  fetch(`/home.json?north=${circleBounds.north}&south=${circleBounds.south}&east=${circleBounds.east}&west=${circleBounds.west}&${filterParam}`)
+  fetch(`/home.json?latitude=${circleLatLng.latitude}&longitude=${circleLatLng.longitude}&${filterParam}`)
     .then(response => response.json())
     .then(data => {
       clearMarkers();

--- a/app/javascript/google_maps.js
+++ b/app/javascript/google_maps.js
@@ -8,6 +8,7 @@ var cafesMarker = [];
 var API_KEY = gon.api_key;
 var currentFilter = 'all';
 var maxMarkers = 10;
+var brandName;
 
 function initMap() {
   map = new google.maps.Map(document.getElementById("map"), {
@@ -69,7 +70,7 @@ function initMap() {
   brandButtons.forEach(function(button) {
     button.addEventListener('click', function(event) {
       var clickedElement = event.target;
-      var brandName = clickedElement.textContent;
+      brandName = clickedElement.textContent;
       currentFilter = 'brand';
       filterSearch(currentFilter, brandName);
       
@@ -92,7 +93,7 @@ window.initMap = initMap;
 function updateSearch() {
   pin.setPosition(map.getCenter());
   circle.setCenter(map.getCenter());
-  filterSearch(currentFilter);
+  filterSearch(currentFilter, brandName);
 }
 
 function filterSearch(filterType, brandName) {

--- a/app/javascript/google_maps.js
+++ b/app/javascript/google_maps.js
@@ -72,21 +72,22 @@ function initMap() {
       var brandName = clickedElement.textContent;
       currentFilter = 'brand';
       filterSearch(currentFilter, brandName);
-
+      
       var dropdown = button.closest('.dropdown');
       if (dropdown) {
         dropdown.removeAttribute('open');
       }
     });
   });
-
+  
   document.getElementById('maps_init').addEventListener('click', function() {
     location.reload();
   });
-
+  
   map.addListener('dragend', updateSearch);
   pin.addListener('dragend', updateSearch);
 }
+window.initMap = initMap;
 
 function updateSearch() {
   pin.setPosition(map.getCenter());
@@ -203,5 +204,3 @@ function clearMarkers() {
   clothesMarker = [];
   cafesMarker = [];
 }
-
-window.initMap = initMap;

--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -1,4 +1,10 @@
 class Shop < ApplicationRecord
+  acts_as_mappable default_units: :kms,
+                   default_formula: :sphere,
+                   distance_field_name: :distance,
+                   lat_column_name: :latitude,
+                   lng_column_name: :longitude
+
   has_many :shop_images, dependent: :destroy
   has_many :shop_brands
   has_many :brands, through: :shop_brands

--- a/app/views/maps/_map.html.erb
+++ b/app/views/maps/_map.html.erb
@@ -1,3 +1,3 @@
 <div id="map" class="w-11/12 h-96 rounded-xl"></div>
 
-<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['MAPS_API_KEY'] %>&callback=initMap" async defer></script>
+<script async="" defer="defer" src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['MAPS_API_KEY'] %>&callback=initMap" ></script>

--- a/config/initializers/geokit_config.rb
+++ b/config/initializers/geokit_config.rb
@@ -1,0 +1,100 @@
+# These defaults are used in Geokit::Mappable.distance_to and acts_as_mappable
+Geokit::default_units = :miles # others :kms, :nms, :meters
+Geokit::default_formula = :sphere
+
+# This is the timeout value in seconds to be used for calls to the geocoder web
+# services.  For no timeout at all, comment out the setting.  The timeout unit
+# is in seconds.
+Geokit::Geocoders::request_timeout = 3
+
+# This setting can be used if web service calls must be routed through a proxy.
+# These setting can be nil if not needed, otherwise, a valid URI must be
+# filled in at a minimum.  If the proxy requires authentication, the username
+# and password can be provided as well.
+# Geokit::Geocoders::proxy = 'https://user:password@host:port'
+
+# This is your yahoo application key for the Yahoo Geocoder.
+# See http://developer.yahoo.com/faq/index.html#appid
+# and http://developer.yahoo.com/maps/rest/V1/geocode.html
+# Geokit::Geocoders::YahooGeocoder.key = 'REPLACE_WITH_YOUR_YAHOO_KEY'
+# Geokit::Geocoders::YahooGeocoder.secret = 'REPLACE_WITH_YOUR_YAHOO_SECRET'
+
+# This is your Google Maps geocoder keys (all optional).
+# See http://www.google.com/apis/maps/signup.html
+# and http://www.google.com/apis/maps/documentation/#Geocoding_Examples
+# Geokit::Geocoders::GoogleGeocoder.client_id = ''
+# Geokit::Geocoders::GoogleGeocoder.cryptographic_key = ''
+# Geokit::Geocoders::GoogleGeocoder.channel = ''
+
+# You can also use the free API key instead of signed requests
+# See https://developers.google.com/maps/documentation/geocoding/#api_key
+# Geokit::Geocoders::GoogleGeocoder.api_key = ''
+
+# You can also set multiple API KEYS for different domains that may be directed
+# to this same application.
+# The domain from which the current user is being directed will automatically
+# be updated for Geokit via
+# the GeocoderControl class, which gets it's begin filter mixed
+# into the ActionController.
+# You define these keys with a Hash as follows:
+# Geokit::Geocoders::google = {
+# 'rubyonrails.org' => 'RUBY_ON_RAILS_API_KEY',
+# ' ruby-docs.org' => 'RUBY_DOCS_API_KEY' }
+
+# This is your username and password for geocoder.us.
+# To use the free service, the value can be set to nil or false.  For
+# usage tied to an account, the value should be set to username:password.
+# See http://geocoder.us
+# and http://geocoder.us/user/signup
+# Geokit::Geocoders::UsGeocoder.key = 'username:password'
+
+# This is your authorization key for geocoder.ca.
+# To use the free service, the value can be set to nil or false.  For
+# usage tied to an account, set the value to the key obtained from
+# Geocoder.ca.
+# See http://geocoder.ca
+# and http://geocoder.ca/?register=1
+# Geokit::Geocoders::CaGeocoder.key = 'KEY'
+
+# This is your username key for geonames.
+# To use this service either free or premium, you must register a key.
+# See http://www.geonames.org
+# Geokit::Geocoders::GeonamesGeocoder.key = 'KEY'
+
+# Most other geocoders need either no setup or a key
+# Geokit::Geocoders::BingGeocoder.key = ''
+# Geokit::Geocoders::MapQuestGeocoder.key = ''
+# Geokit::Geocoders::YandexGeocoder.key = ''
+# Geokit::Geocoders::MapboxGeocoder.key = 'ACCESS_TOKEN'
+# Geokit::Geocoders::OpencageGeocoder.key = 'some_api_key'
+
+# Geonames has a free service and a premium service, each using a different URL
+# GeonamesGeocoder.premium = true will use http://ws.geonames.net (premium)
+# GeonamesGeocoder.premium = false will use http://api.geonames.org (free)
+# Geokit::Geocoders::GeonamesGeocoder.premium = false
+
+# require "external_geocoder.rb"
+# Please see the section "writing your own geocoders" for more information.
+# Geokit::Geocoders::external_key = 'REPLACE_WITH_YOUR_API_KEY'
+
+# This is the order in which the geocoders are called in a failover scenario
+# If you only want to use a single geocoder, put a single symbol in the array.
+# Valid symbols are :google, :yahoo, :us, and :ca.
+# Be aware that there are Terms of Use restrictions on how you can use the
+# various geocoders.  Make sure you read up on relevant Terms of Use for each
+# geocoder you are going to use.
+# Geokit::Geocoders::provider_order = [:google,:us]
+
+# The IP provider order. Valid symbols are :ip,:geo_plugin.
+# As before, make sure you read up on relevant Terms of Use for each.
+# Geokit::Geocoders::ip_provider_order = [:external,:geo_plugin,:ip]
+
+# Disable HTTPS globally.  This option can also be set on individual
+# geocoder classes.
+# Geokit::Geocoders::secure = false
+
+# Control verification of the server certificate for geocoders using HTTPS
+# Geokit::Geocoders::ssl_verify_mode = OpenSSL::SSL::VERIFY_(PEER/NONE)
+# Setting this to VERIFY_NONE may be needed on systems that don't have
+# a complete or up to date root certificate store. Only applies to
+# the Net::HTTP adapter.


### PR DESCRIPTION
## 内容
- ブランドから検索をクリックした際に、ブランド名を保持したまま検索ができていなかったので修正しました。
- マップ検索をする際に、サークル外のショップも該当して表示されていたので、gem 'geokit-rails'を導入して、サークルと同じ半径の範囲で検索をするように修正しました。

## 確認事項
- ブランド名を保持したまま検索ができているか。
- サークルの範囲内で検索ができているか。

## 確認結果
「ブランド名を保持できているか」
![51fdaf70b0c3042ce058d4362c17bece](https://github.com/jinta-shimo02/fuku_cafe/assets/100778581/e686723a-295b-4528-a237-062a76ac5007)

「サークルの範囲内で検索ができているか」
![7d33fd7fbc39a3ae5911182dabd0714d](https://github.com/jinta-shimo02/fuku_cafe/assets/100778581/cfbacc70-e523-429d-890c-2526e3167afa)

