### PR TITLE
ショップ詳細画面からリスト保存できるよう修正

### DIFF
--- a/app/views/shops/show.html.erb
+++ b/app/views/shops/show.html.erb
@@ -1,7 +1,14 @@
 <div class="grid place-items-center">
   <div class="card w-11/12 md:w-4/5 bg-base-100 shadow-md z-0 rounded-3xl my-20">
     <div class="card-body pt-10 md:pt-20">
-      <p class="text-base md:text-2xl underline pl-5 md:pl-10"><%= @shop.name %></p>
+      <div class="flex" data_controller="modal">
+        <p class="text-base md:text-2xl underline pl-5 md:pl-10"><%= @shop.name %></p>
+        <% if user_signed_in? %>
+          <a href="/shop_saved_lists" data-turbo-frame="modal" class="ml-auto mr-3 mt-auto mr-5 md:mr-10 m-5 bookmark-icon" data-shop-id="<%= @shop.id %>">
+            <i class="fa-solid fa-plus w-7 g-4 md:w-14 md:h-8 hover:text-yellow-500" data-modal-target="myModal"></i>
+          </a>
+        <% end %>
+      </div>
       <p class="pl-10 md:pl-20 mt-4 text-[10px] md:text-lg">住　　所：<%= @shop.address %></p>
       <div class="flex">
         <div class="pl-10 md:pl-20 mt-4 text-[10px] md:text-lg">営業時間：</div>


### PR DESCRIPTION
## 内容
- ショップ詳細画面からリスト保存できるように保存ボタンを追加しました。

## 確認事項
- ショップ詳細画面からリストへ保存できているか。
- ログインしていない時に保存ボタンが表示されていないか。

## 確認結果
「ショップ詳細画面からリスト保存できているか。」
![00bf245f2938968406fc3008801b867b](https://github.com/jinta-shimo02/fuku_cafe/assets/100778581/070b67f6-7c06-488d-bf94-9161654f0fe9)

「ログインしていない時に保存ボタンが表示されていないか。」
![444e4576a9088471a947b5bda66e82b5](https://github.com/jinta-shimo02/fuku_cafe/assets/100778581/518b2c7a-7ba5-4d6f-9b43-c828b6fc5906)

