### PR TITLE
ユーザー登録時にデフォルトのリストを作成

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,10 +3,17 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+  after_create :create_initial_list
 
   has_many :shop_saved_lists, dependent: :destroy
 
   enum role: { general: 0, admin: 1 }
 
   validates :name, presence: true, length: { maximum: 255 }
+
+  private
+
+  def create_initial_list
+    shop_saved_lists.create(name: 'お気に入り')
+  end
 end


### PR DESCRIPTION
## 内容
- ユーザー登録をした際に、デフォルトのリストを１つ作成するようにしました。

## 確認事項
- ユーザー登録の際に、「お気に入り」のリストが作成されているか。

## 確認結果
「動作画面」
![ef2f236e873936c155bafd33f87ec122](https://github.com/jinta-shimo02/fuku_cafe/assets/100778581/f7852a89-1740-4025-870a-dfc78cf6dde0)

「ログ」
<img width="941" alt="2b02ea4d4bdc512dc7bb9425ec598dbc" src="https://github.com/jinta-shimo02/fuku_cafe/assets/100778581/c6f862fe-5070-4d80-9e07-e07342b7d40f">
