### PR TITLE
情報ウィンドウをクリックするとショップ詳細画面へ遷移

### DIFF
--- a/app/javascript/google_maps.js
+++ b/app/javascript/google_maps.js
@@ -186,7 +186,7 @@ function addMarkers(shops, type) {
     });
 
     const infowindow = new google.maps.InfoWindow({
-      content: '<div><strong>' + shops[i].name + '</strong></div>'
+      content: '<div class="hover:text-yellow-500"><a href="/shops/' + shops[i].id + '">' + shops[i].name + '</a></div>'
     });
 
     marker.addListener('click', function() {


### PR DESCRIPTION
## 内容
- GoogleMap上のマーカーをクリックすると表示される情報ウィンドウをクリックすると、ショップの詳細画面へ遷移するようにしました。

## 確認事項
- 情報ウィンドウをクリックすると、ショップの詳細画面へ遷移するか。

## 確認結果
![362d0551d1fd3daec8d13fa654afcc23](https://github.com/jinta-shimo02/fuku_cafe/assets/100778581/0a64b691-717c-4b95-a46c-46f9d64ca6c9)
