### PR TITLE
レビュー表示の修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,6 +81,9 @@ gem 'geokit-rails'
 # SEO
 gem 'meta-tags'
 
+# pagenate
+gem 'kaminari'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -364,6 +364,7 @@ DEPENDENCIES
   google_places
   jbuilder
   jsbundling-rails
+  kaminari
   meta-tags
   pg (~> 1.1)
   pry-rails

--- a/app/controllers/my_pages_controller.rb
+++ b/app/controllers/my_pages_controller.rb
@@ -3,6 +3,7 @@ class MyPagesController < ApplicationController
 
   def show
     @shop_saved_lists = current_user.shop_saved_lists
+    @reviews = current_user.reviews.includes(:shop).order(created_at: :desc)
   end
 
   def edit; end

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -1,5 +1,5 @@
 class ReviewsController < ApplicationController
-  before_action :set_shop, only: %i[new create]
+  before_action :set_shop, only: %i[new create more]
   before_action :set_review, only: %i[edit update destroy]
 
   def new
@@ -39,6 +39,14 @@ class ReviewsController < ApplicationController
     render turbo_stream: [
       turbo_stream.remove(@review),
       turbo_stream.update("flash", partial: "shared/flash")
+    ]
+  end
+
+  def more
+    @reviews = @shop.reviews.includes(:user).order(created_at: :desc).page(params[:page]).per(3)
+    render turbo_stream: [
+      turbo_stream.append("reviews", partial: "review", collection: @reviews),
+      turbo_stream.update("more_link", partial: "more_link")
     ]
   end
 

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -4,6 +4,6 @@ class ShopsController < ApplicationController
   def show
     @shop = Shop.find(params[:id])
     @shop_images = @shop.shop_images
-    @reviews = @shop.reviews.includes(:user).order(created_at: :desc)
+    @reviews = @shop.reviews.includes(:user).order(created_at: :desc).page(params[:page]).per(3)
   end
 end

--- a/app/views/maps/home.html.erb
+++ b/app/views/maps/home.html.erb
@@ -4,17 +4,17 @@
   <div class="card w-11/12 bg-base-100 shadow-md z-0 mt-5 mb-10">
     <div class="card-body p-10">
       <div class="flex flex-col justify-center items-center h-full">
-        <h2 class="text-left text-lg md:text-3xl border-b border-gray-500 w-11/12 p-5">セレクトショップ</h2>
+        <h2 class="text-left text-lg md:text-2xl border-b border-gray-500 w-11/12 p-5">セレクトショップ</h2>
           <div id="clothes-list">
-            <p class="text-base md:text-2xl pt-5 text-center" id="no-clothes-shops">近くにショップはありません</p>
+            <p class="text-base md:text-lg pt-5 text-center" id="no-clothes-shops">近くにショップはありません</p>
           </div>
       </div>
     </div>
     <div class="card-body p-10">
       <div class="flex flex-col justify-center items-center h-full">
-        <h2 class="text-left text-lg md:text-3xl border-b border-gray-500 w-11/12 p-5">カフェ</h2>
+        <h2 class="text-left text-lg md:text-2xl border-b border-gray-500 w-11/12 p-5">カフェ</h2>
           <div id="cafes-list">
-            <p class="text-base md:text-2xl py-5 text-center">近くにショップはありません</p>
+            <p class="text-base md:text-lg py-5 text-center">近くにショップはありません</p>
           </div>
         </div>
       </div>

--- a/app/views/my_pages/show.html.erb
+++ b/app/views/my_pages/show.html.erb
@@ -14,12 +14,12 @@
       <div class="flex justify-center items-center h-full">
         <div class="card w-full md:w-11/12 bg-base-200 border-gray-500 shadow-xl">
           <div class="border-b border-gray-500 p-5">
-            <h2 class="text-base md:text-xl"><%= t('defaults.shop_saved_list')%></h3>
+            <h2 class="text-sm md:text-lg"><%= t('defaults.shop_saved_list')%></h3>
           </div>
           <div class="card-body p-2 md:p-5">
             <% @shop_saved_lists.each do |list| %>
-              <div class="flex justify-between border-b border-gray-500">
-                <%= link_to list.name, shop_saved_list_path(list), class: 'text-sm md:text-base text-left border-b p-3 hover:text-yellow-500'%>
+              <div class="flex justify-between items-center border-b border-gray-400">
+                <%= link_to list.name, shop_saved_list_path(list), class: 'text-xs md:text-base text-left p-3 hover:text-yellow-500'%>
                 <%= link_to '削除', shop_saved_list_path(list), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' }, class: 'w-16 btn btn-sm md:btn-md bg-red-400 text-white my-2' %>
               </div>
             <% end %>
@@ -27,20 +27,33 @@
         </div>
       </div>
     </div>
-    <div class="card-body p-10">
-      <div class="flex flex-col justify-center items-center h-full">
-        <h2 class="text-left text-base md:text-xl border-b border-gray-500 w-11/12 p-5">レビューしたショップ（まだ機能していません）</h2>
-        <div class="card w-11/12 bg-base-200 border-gray-500 shadow-md m-2">
-          <p class="p-7">ショップ情報</p>
-        </div>
-        <div class="card w-11/12 bg-base-200 border-gray-500 shadow-md m-2">
-          <p class="p-7">ショップ情報</p>
-        </div>
-        <div class="card w-11/12 bg-base-200 border-gray-500 shadow-md m-2">
-          <p class="p-7">ショップ情報</p>
-        </div>
-        <div class="card w-11/12 bg-base-200 border-gray-500 shadow-md m-2">
-          <p class="p-7">ショップ情報</p>
+    <div class="card-body border-t border-gray-500 p-10">
+      <div class="flex justify-center items-center h-full">
+        <div class="card w-full md:w-11/12 bg-base-200 shadow-xl">
+          <p class="p-5 text-sm md:text-lg border-b border-gray-500">マイレビュー</p>
+          <% if @reviews.any? %>
+            <% @reviews.each do |review| %>
+              <div class="border-b border-gray-400 py-5 mx-5">
+                <div class="flex justify-between mx-2 items-center">
+                  <div class="text-left">
+                    <%= link_to review.shop.name, shop_path(review.shop), class: 'text-[10px] md:text-sm hover:text-yellow-500' %>
+                  </div>
+                  <div class="text-right">
+                    <p class="text-[10px] md:text-sm text-gray-500"><%= l review.created_at, format: :simple %></p>
+                  </div>
+                </div>
+                <div class="flex flex-col mt-1.5 mb-1.5 p-2 mx-2 border rounded-lg border-gray-300">
+                  <div class="flex items-center mb-2">
+                    <i class="fa-solid fa-star text-yellow-500 mr-2"></i>
+                    <p class="text-[10px] md:text-sm"><%= review.rating_as_number %></p>
+                  </div>
+                  <p class="text-[10px] md:text-sm"><%= review.content %></p>
+                </div>
+              </div>
+            <% end %>
+          <% else %>
+            <p class="text-[10px] md:text-sm py-5 text-center">レビューがありません</p>
+          <% end %>
         </div>
       </div>
     </div>

--- a/app/views/reviews/_more_link.html.erb
+++ b/app/views/reviews/_more_link.html.erb
@@ -1,0 +1,3 @@
+<% if @reviews.next_page %>
+  <%= link_to 'さらに表示', more_shop_reviews_path(@shop, page: @reviews.next_page), class: 'border rounded-full bg-yellow-500 text-white py-1 px-5 hover:bg-yellow-600' %>
+<% end %>

--- a/app/views/shops/show.html.erb
+++ b/app/views/shops/show.html.erb
@@ -29,7 +29,7 @@
       <p class="pl-10 md:pl-20 mt-4 text-[10px] md:text-lg">ギャラリー</p>
       <div class="flex overflow-x-hidden">
         <% @shop_images.each do |shop_image| %>
-          <img src="https://maps.googleapis.com/maps/api/place/photo?maxheight=1000&maxwidth=1000&photo_reference=<%= shop_image.image %>&key=<%= ENV['API_KE'] %>" class="mx-2 rounded-xl w-12 h-12 md:w-32 md:h-32">
+          <img src="https://maps.googleapis.com/maps/api/place/photo?maxheight=1000&maxwidth=1000&photo_reference=<%= shop_image.image %>&key=<%= ENV['API_KEY'] %>" class="mx-2 rounded-xl w-12 h-12 md:w-32 md:h-32">
         <% end %>
       </div>
     </div>

--- a/app/views/shops/show.html.erb
+++ b/app/views/shops/show.html.erb
@@ -29,7 +29,7 @@
       <p class="pl-10 md:pl-20 mt-4 text-[10px] md:text-lg">ギャラリー</p>
       <div class="flex overflow-x-hidden">
         <% @shop_images.each do |shop_image| %>
-          <img src="https://maps.googleapis.com/maps/api/place/photo?maxheight=1000&maxwidth=1000&photo_reference=<%= shop_image.image %>&key=<%= ENV['API_KEY'] %>" class="mx-2 rounded-xl w-12 h-12 md:w-32 md:h-32">
+          <img src="https://maps.googleapis.com/maps/api/place/photo?maxheight=1000&maxwidth=1000&photo_reference=<%= shop_image.image %>&key=<%= ENV['API_KE'] %>" class="mx-2 rounded-xl w-12 h-12 md:w-32 md:h-32">
         <% end %>
       </div>
     </div>
@@ -40,6 +40,11 @@
               <div id="reviews">
                 <%= turbo_frame_tag 'review_modal' do %>
                   <%= render @reviews %>
+                <% end %>
+              </div>
+              <div class="text-center text-xs md:text-sm mt-5">
+                <%= turbo_frame_tag 'more_link' do %>
+                  <%= render 'reviews/more_link' %>
                 <% end %>
               </div>
               <% if user_signed_in? %>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  # config.default_per_page = 25
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,11 @@ Rails.application.routes.draw do
 
   resources :shops, only: %i[show] do 
     resources :list_shops, only: %i[create destroy]
-    resources :reviews, only: %i[new create destroy edit update destroy], shallow: true
+    resources :reviews, only: %i[new create destroy edit update destroy], shallow: true do
+      collection do
+        get :more
+      end
+    end
   end
   resources :shop_saved_lists
 end


### PR DESCRIPTION
## 内容
- ショップ詳細画面のレビューについて、デフォルトでは３件表示するようにし、それ以降のレビューについては、「さらに表示」ボタンをクリックすると、閲覧できるように修正しました。
- マイページ画面のマイレビュー部分で、自分がレビューしたショップを閲覧できるようにしました。

## 確認事項
- 「さらに表示」ボタンをクリックすると、４件目以降のレビューが表示されるか。
- マイページ画面で、自分がレビューしたショップが表示されているか。

## 確認結果
「「さらに表示」ボタンをクリックすると、４件目以降のレビューが表示されるか。」
![ad64a5b5bec347b23005519870046165](https://github.com/jinta-shimo02/fuku_cafe/assets/100778581/31172f20-bfae-451c-b2a0-b72270bcfbb2)

「マイページ画面で、自分がレビューしたショップが表示されているか。」
<img width="951" alt="8f5a11efcda692af97bbcc74ed9680f9" src="https://github.com/jinta-shimo02/fuku_cafe/assets/100778581/662b4534-9a32-4544-a8ea-57ad450aa202">
