### PR TITLE
現在地を取得すると情報ウィンドウが表示されるよう修正

### DIFF
--- a/app/javascript/google_maps.js
+++ b/app/javascript/google_maps.js
@@ -9,6 +9,7 @@ var API_KEY = gon.api_key;
 var currentFilter = 'all';
 var maxMarkers = 10;
 var brandName;
+var infoWindow;
 
 function initMap() {
   map = new google.maps.Map(document.getElementById("map"), {
@@ -76,6 +77,7 @@ function initMap() {
     map.setCenter(new google.maps.LatLng(lat, lng));
   });
 
+  infoWindow = new google.maps.InfoWindow();
   var currentLocationButton = document.createElement('button');
   currentLocationButton.textContent = "現在地へ移動";
   currentLocationButton.className = "border-2 rounded-full border-orange-400 bg-orange-400 py-2 px-4 md:px-8 mt-2 mr-2 text-center text-xs md:text-base text-white font-bold hover:bg-orange-600";
@@ -93,13 +95,17 @@ function initMap() {
           circle.setCenter(new google.maps.LatLng(lat, lng));
 
           map.setCenter(new google.maps.LatLng(lat, lng));
+
+          infoWindow.setPosition(new google.maps.LatLng(lat, lng));
+          infoWindow.setContent("現在地を取得しました");
+          infoWindow.open(map);
         },
         () => {
-          handleLocationError(true, map.getCenter());
+          handleLocationError(true, infoWindow, map.getCenter());
         }
       );
     } else {
-      handleLocationError(false, map.getCenter());
+      handleLocationError(false, infoWindow, map.getCenter());
     }
   });
   
@@ -249,4 +255,14 @@ function clearMarkers() {
   cafesMarker.forEach(marker => marker.setMap(null));
   clothesMarker = [];
   cafesMarker = [];
+}
+
+function handleLocationError(browserHasGeolocation, infoWindow, lat, lng) {
+  infoWindow.setPosition(new google.maps.LatLng(lat, lng));
+  infoWindow.setContent(
+    browserHasGeolocation
+      ? "現在地を取得できませんでした"
+      : "お使いのブラウザではサポートされていません"
+  );
+  infoWindow.open(map);
 }


### PR DESCRIPTION
## 内容
- 現在地を取得すると、「現在地を取得しました」と情報ウィンドウで表示するようにしました。
- 現在地の取得に失敗すると、「現在地を取得できませんでした」と情報ウィンドウで表示するようにしました。

## 確認事項
- 現在地を取得すると、「現在地を取得しました」と表示されているか。
- 現在地の取得に失敗すると、「現在地を取得できませんでした」と表示されているか。

 ## 確認結果
「現在地を取得」
<img width="280" alt="25d7b153a21337d58ab3d3000bd71de4" src="https://github.com/jinta-shimo02/fuku_cafe/assets/100778581/d8fcaead-06bd-4a71-a681-11cd90ec9eb3">
「現在地の取得に失敗」
![09ad2b84aeefd6fb517537783b97031e](https://github.com/jinta-shimo02/fuku_cafe/assets/100778581/a8dd9934-0c7e-4e0c-9467-e0d6646aa784)