### PR TITLE
jsのアラートをフラッシュメッセージへ変更

### DIFF
--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -42,13 +42,14 @@ export default class extends Controller {
       })
       .then(data => {
         if (data.success) {
-          alert(`${data.name}に保存しました`);
+          this.setFlashMessage("success", `${data.name}へ保存しました`);
         } else {
-          alert('すでに保存しています');
+          this.setFlashMessage("error", `すでに保存しています`);
         }
       })
       .catch(error => {
         console.error("リクエストエラー", error);
+        this.setFlashMessage("error", "リクエストエラーが発生しました");
       });
     }
     this.myModalTarget.classList.add("hidden");
@@ -62,5 +63,27 @@ export default class extends Controller {
     // クリックされたブックマークボタンから data-shop-id を取得
     const clickedButton = event.currentTarget;
     shopId = clickedButton.getAttribute("data-shop-id"); // グローバル変数に代入
-  } 
+  }
+
+  setFlashMessage(type, message) {
+    const flashContainer = document.createElement("div");
+    flashContainer.classList.add("flex", "items-center", "text-white", "text-xs", "md:text-sm", "font-bold", "pl-10", "py-5");
+
+    if (type === "success") {
+      flashContainer.classList.add("bg-green-400");
+    } else if (type === "error") {
+      flashContainer.classList.add("bg-red-400");
+    }
+
+    flashContainer.textContent = message;
+
+    const flashContainerElement = document.getElementById("flash");
+
+    if (flashContainerElement) {
+      flashContainerElement.appendChild(flashContainer);
+      setTimeout(() => {
+        flashContainerElement.removeChild(flashContainer);
+      }, 5000)
+    }
+  }
 }


### PR DESCRIPTION
## 内容
- ショップをリストへ保存した際に、jsのアラートで保存メッセージを表示していたので、フラッシュメッセージで表示するように変更しました。

## 確認事項
- リスト保存成功時にフラッシュメッセージが表示されているか。
- リスト保存失敗時にフラッシュメッセージが表示されているか。

## 確認結果
「成功時」
![7da4d36a379b1ed3cd1a402fbf1b3e9a](https://github.com/jinta-shimo02/fuku_cafe/assets/100778581/97f7a71c-c2fb-473a-8e52-3acf39d4e1f3)
「失敗時」
![0becf2063f5091655d46625e525080ff](https://github.com/jinta-shimo02/fuku_cafe/assets/100778581/25dc40c2-f64e-4317-ac26-282f1b84b89e)
