### PR TITLE
ショップ詳細画面で近くにあるショップをレコメンド

### DIFF
--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -4,6 +4,7 @@ class ShopsController < ApplicationController
   def show
     @shop = Shop.find(params[:id])
     @shop_images = @shop.shop_images
+    @closest_shop = @shop.closest_shop(@shop.latitude, @shop.longitude)
     @reviews = @shop.reviews.includes(:user).order(created_at: :desc).page(params[:page]).per(3)
   end
 end

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -3,7 +3,7 @@ import { Controller } from "@hotwired/stimulus"
 shopId = null;
 
 export default class extends Controller {
-  static targets = ["myModal"]
+  static targets = ["myModal", "recommendModal"]
 
   connect() {
     // "bookmark-icon" クラスの要素を取得
@@ -44,7 +44,7 @@ export default class extends Controller {
         if (data.success) {
           this.setFlashMessage("success", `${data.name}へ保存しました`);
         } else {
-          this.setFlashMessage("error", `すでに保存しています`);
+          this.setFlashMessage("error", "すでに保存しています");
         }
       })
       .catch(error => {

--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -20,4 +20,16 @@ class Shop < ApplicationRecord
   def clothes?
     type == "Clothes"
   end
+
+  def closest_shop(latitude, longitude)
+    if type == 'Clothes'
+      target_location = Geokit::LatLng.new(latitude, longitude)
+      clothes_closest_shop = Clothes.where.not(id: self.id).closest(origin: target_location, units: :kms, within: 10).first
+      clothes_closest_shop
+    else
+      target_location = Geokit::LatLng.new(latitude, longitude)
+      cafe_closest_shop = Cafe.where.not(id: self.id).closest(origin: target_location, units: :kms, within: 10).first
+      cafe_closest_shop
+    end
+  end
 end

--- a/app/views/shops/_recommend_shop.html.erb
+++ b/app/views/shops/_recommend_shop.html.erb
@@ -1,0 +1,28 @@
+<div class="card-body border-t border-gray-400 p-5">
+  <p class="text-sm md: text-base ml-5">近くにおすすめのショップがあります</p>
+  <div class="flex justify-center items-center h-full">
+    <div class="card w-full bg-base-200 border-gray-500 shadow-xl m-2">
+      <div class="flex">
+          <img src="https://maps.googleapis.com/maps/api/place/photo?maxheight=200&maxwidth=200&photo_reference=<%= closest_shop.shop_images[0].image %>&key=<%= ENV["API_KEY"] %>" class="p-3 md:p-5 w-20 h-20 md:w-32 md:h-32 rounded-3xl">
+          <div class="flex-col">
+            <ul>
+              <li class="md:pl-4 pt-3 text-xs md:text-base underline hover:text-yellow-500">
+                <%= link_to closest_shop.name, shop_path(closest_shop) %>
+              </li>
+              <li class="md:pl-4 pt-1.5 text-[10px] md:text-xs">
+                <%= closest_shop.address %>
+              </li>
+              <li class="md:pl-4 pt-1.5 text-[10px] md:text-xs">
+                <%= closest_shop.phone_number %>
+              </li>
+              <a href="https://www.google.com/maps/search/?api=1&query=<%= closest_shop.name %>&query_place_id=<%= closest_shop.place_id %>" target="_blank" rel="noopener noreferrer">
+            <li class="mt-1.5 py-1 px-1 text-center rounded-full bg-blue-500 text-white font-bold w-36 hidden md:block hover:bg-gray-300">
+              <i class="fa-solid fa-location-dot"></i>
+              <span class="text-[10px] md:text-xs">GoogleMapで見る</span>
+            </li>
+            </a>
+          </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/shops/show.html.erb
+++ b/app/views/shops/show.html.erb
@@ -33,27 +33,28 @@
         <% end %>
       </div>
     </div>
-      <div class="card-body border-t border-gray-500 p-10">
-        <div class="flex justify-center items-center h-full">
-          <div class="card w-full bg-base-200 shadow-xl">
-            <p class="pl-10 py-4 md:py-7 text-sm md:text-lg border-b border-gray-500">レビュー</p>
-              <div id="reviews">
-                <%= turbo_frame_tag 'review_modal' do %>
-                  <%= render @reviews %>
-                <% end %>
-              </div>
-              <div class="text-center text-xs md:text-sm mt-5">
-                <%= turbo_frame_tag 'more_link' do %>
-                  <%= render 'reviews/more_link' %>
-                <% end %>
-              </div>
-              <% if user_signed_in? %>
-                <div class="flex justify-end mx-10 mt-5 md:mt-10 mb-5">
-                  <%= link_to 'レビューを書く', new_shop_review_path(@shop), class: 'btn btn-sm md:btn-md btn-neutral', data: { turbo_frame: 'review_modal' } %>
-                </div>
+    <%= render 'recommend_shop', closest_shop: @closest_shop %>
+    <div class="card-body border-t border-gray-400 p-10">
+      <div class="flex justify-center items-center h-full">
+        <div class="card w-full bg-base-200 shadow-xl">
+          <p class="pl-10 py-4 md:py-7 text-sm md:text-lg border-b border-gray-500">レビュー</p>
+            <div id="reviews">
+              <%= turbo_frame_tag 'review_modal' do %>
+                <%= render @reviews %>
               <% end %>
-          </div>
+            </div>
+            <div class="text-center text-xs md:text-sm mt-5">
+              <%= turbo_frame_tag 'more_link' do %>
+                <%= render 'reviews/more_link' %>
+              <% end %>
+            </div>
+            <% if user_signed_in? %>
+              <div class="flex justify-end mx-10 mt-5 md:mt-10 mb-5">
+                <%= link_to 'レビューを書く', new_shop_review_path(@shop), class: 'btn btn-sm md:btn-md btn-neutral', data: { turbo_frame: 'review_modal' } %>
+              </div>
+            <% end %>
         </div>
       </div>
+    </div>
   </div>
 </div>

--- a/config/initializers/geokit_config.rb
+++ b/config/initializers/geokit_config.rb
@@ -1,5 +1,5 @@
 # These defaults are used in Geokit::Mappable.distance_to and acts_as_mappable
-Geokit::default_units = :miles # others :kms, :nms, :meters
+Geokit::default_units = :kms # others :miles, :nms, :meters
 Geokit::default_formula = :sphere
 
 # This is the timeout value in seconds to be used for calls to the geocoder web


### PR DESCRIPTION
## 内容
- ショップ詳細画面で、開いているショップに1番近いショップをレコメンドする機能を追加しました。

## レコメンドのロジック
- shop.rbでは、gem 'geokit-rails'のメソッドである「closest」を使用して、データベースに保存している緯度経度を元に、1番近くにあるショップを検索するカスタムメソッドを作成しました。「where.not」を使用しているのは、メソッドを呼び出しているインスタンス自身を検索の対象に含んでいたためです。
```
#shop.rb
def closest_shop(latitude, longitude)
    if type == 'Clothes'
      target_location = Geokit::LatLng.new(latitude, longitude)
      clothes_closest_shop = Clothes.where.not(id: self.id).closest(origin: target_location, units: :kms, within: 10).first
      clothes_closest_shop
    else
      target_location = Geokit::LatLng.new(latitude, longitude)
      cafe_closest_shop = Cafe.where.not(id: self.id).closest(origin: target_location, units: :kms, within: 10).first
      cafe_closest_shop
    end
  end
```
- shop_controller.rbでは、@shopにclosest_shopを使用することで、ショップ詳細画面で表示しているショップに1番近いショップを検索しています。
```
#shop_controller.rb
class ShopsController < ApplicationController
  skip_before_action :authenticate_user!

  def show
    @shop = Shop.find(params[:id])
    @shop_images = @shop.shop_images
    @closest_shop = @shop.closest_shop(@shop.latitude, @shop.longitude)
    @reviews = @shop.reviews.includes(:user).order(created_at: :desc).page(params[:page]).per(3)
  end
end
```

## 確認事項
- ショップ詳細画面で、レコメンドしたショップが表示されているか。

##   確認結果
<img width="943" alt="9691898ec9552e92a3d8e017c849f2d5" src="https://github.com/jinta-shimo02/fuku_cafe/assets/100778581/0c803fee-d60f-40ef-8eed-e1b69c34259b">
