### PR TITLE
モーダル外をクリックするとモーダルが閉じるように修正

### DIFF
--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -3,20 +3,14 @@ import { Controller } from "@hotwired/stimulus"
 shopId = null;
 
 export default class extends Controller {
-  static targets = ["myModal", "recommendModal"]
+  static targets = ["myModal", "backGround"]
 
   connect() {
-    // "bookmark-icon" クラスの要素を取得
     const bookmarkButtons = document.getElementsByClassName("bookmark-icon");
-      
-    // 各ブックマークボタンにクリックイベントリスナーを追加
+
     for (const bookmarkButton of bookmarkButtons) {
       bookmarkButton.addEventListener("click", this.buttonClick);
     }
-  }
-
-  open() {
-    this.myModalTarget.classList.remove('hidden');
   }
   
   close(event) {
@@ -25,12 +19,12 @@ export default class extends Controller {
 
     if (shopId && listId) {
       const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
-
+      
       fetch(`/shops/${shopId}/list_shops?list_id=${listId}`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'X-CSRF-Token': csrfToken, // CSRFトークンを追加
+          'X-CSRF-Token': csrfToken, 
         },
       })
       .then(response => {
@@ -52,38 +46,43 @@ export default class extends Controller {
         this.setFlashMessage("error", "リクエストエラーが発生しました");
       });
     }
-    this.myModalTarget.classList.add("hidden");
+    this.backGroundTarget.classList.add("hidden");
   }
-
-  new_list_close(event) {
-      this.myModalTarget.classList.add("hidden");
+  
+  closeModal() {
+    this.backGroundTarget.classList.add("hidden");
   }
-
+  
   buttonClick(event) {
-    // クリックされたブックマークボタンから data-shop-id を取得
     const clickedButton = event.currentTarget;
-    shopId = clickedButton.getAttribute("data-shop-id"); // グローバル変数に代入
+    shopId = clickedButton.getAttribute("data-shop-id");
   }
-
+  
   setFlashMessage(type, message) {
     const flashContainer = document.createElement("div");
     flashContainer.classList.add("flex", "items-center", "text-white", "text-xs", "md:text-sm", "font-bold", "pl-10", "py-5");
-
+    
     if (type === "success") {
       flashContainer.classList.add("bg-green-400");
     } else if (type === "error") {
       flashContainer.classList.add("bg-red-400");
     }
-
+    
     flashContainer.textContent = message;
-
+    
     const flashContainerElement = document.getElementById("flash");
-
+    
     if (flashContainerElement) {
       flashContainerElement.appendChild(flashContainer);
       setTimeout(() => {
         flashContainerElement.removeChild(flashContainer);
       }, 5000)
+    }
+  }
+
+  closeBackground(event) {
+    if(event.target === this.backGroundTarget) {
+      this.closeModal();
     }
   }
 }

--- a/app/views/shop_saved_lists/index.html.erb
+++ b/app/views/shop_saved_lists/index.html.erb
@@ -1,7 +1,10 @@
 <%= turbo_frame_tag "modal" do %>
-  <div id="myModal" class="fixed inset-0 flex items-center justify-center z-50 bg-gray-500 bg-opacity-50" data-controller="modal" data-modal-target="myModal">
-    <div class="modal-content bg-white rounded-xl shadow-lg p-10 w-80 md:w-[450px]">
-      <h2 class="text-base md:text-lg font-semibold mb-6">リストへ保存</h2>
+  <div id="myModal" class="fixed inset-0 flex items-center justify-center z-50 bg-gray-500 bg-opacity-50" data-controller="modal" data-modal-target="backGround" data-action="click->modal#closeBackground">
+    <div class="modal-content bg-white rounded-xl shadow-lg p-10 w-80 md:w-[450px]" data-modal-target="myModal">
+      <div class="flex justify-between items-center mb-6">
+      <h2 class="text-base md:text-lg font-semibold">リストへ保存</h2>
+      <i class="fa-solid fa-xmark h-6 w-6 hover:text-yellow-500" data-action="click->modal#closeModal"></i>    
+      </div>
       <% @shop_saved_lists.each do |list| %>
         <div class="flex justify-center mb-5 border-b pb-2 list-button" data-action="click->modal#close" data-list-id="<%= list.id %>">
         <button class="text-xs md:text-base hover:text-yellow-500"><%= list.name %></button>

--- a/app/views/shop_saved_lists/new.html.erb
+++ b/app/views/shop_saved_lists/new.html.erb
@@ -1,8 +1,11 @@
 <%= turbo_frame_tag "modal" do %>
-  <div id="myModal" class="fixed inset-0 flex items-center justify-center z-50 bg-gray-500 bg-opacity-50" data-controller="modal" data-modal-target="myModal">
-    <div class="modal-content bg-white rounded-xl shadow-lg p-5 md:p-10 w-80 md:w-[450px]">
-      <h2 class="text-base md:text-lg font-semibold mb-6">新しいリスト</h2>
-      <%= form_with model: @shop_saved_list, data: { action: "turbo:submit-end->modal#new_list_close"} do |f| %>
+  <div id="myModal" class="fixed inset-0 flex items-center justify-center z-50 bg-gray-500 bg-opacity-50" data-controller="modal" data-modal-target="backGround" data-action="click->modal#closeBackground">
+    <div class="modal-content bg-white rounded-xl shadow-lg p-5 md:p-10 w-80 md:w-[450px]" data-modal-target="myModal">
+      <div class="flex justify-between items-center mb-6">
+        <h2 class="text-base md:text-lg font-semibold">新しいリスト</h2>
+        <i class="fa-solid fa-xmark h-6 w-6 hover:text-yellow-500" data-action="click->modal#closeModal"></i>
+      </div>
+      <%= form_with model: @shop_saved_list, data: { action: "turbo:submit-end->modal#closeModal"} do |f| %>
         <%= render 'shared/error_messages', object: f.object %>
         <div class="flex flex-col justify-center mt-4">
           <%= f.text_field :name, class: 'input input-warning border-gray-800' %>


### PR DESCRIPTION
## 内容
- リスト保存、リスト作成をする際に表示されるモーダルについて、モーダル外をクリックすると、モーダルが閉じるように修正しました。また、念の為、モーダル内に「✖️」を設置し、「✖️」をクリックしてもモーダルが閉じるようにしました。

## 確認事項
- モーダル外をクリックするとモーダルが閉じるか。
- モーダル内の「✖️」をクリックするとモーダルが閉じるか。


## 確認結果
「モーダル外をクリック」
![b0d7df6c096157895d591a7761af0485](https://github.com/jinta-shimo02/fuku_cafe/assets/100778581/427736c6-596c-46e7-b471-7c9183e0fde4)

「モーダル内の「✖️」をクリック」
![b2d872fc7fa4c35257fcabb50119218b](https://github.com/jinta-shimo02/fuku_cafe/assets/100778581/fed6fa38-d7e0-4ad1-8b0c-172ae1ef0ded)

