### PR TITLE
レビュー用のモーダル外をクリックするとモーダルが閉じるよう修正

### DIFF
--- a/app/javascript/controllers/review_modal_controller.js
+++ b/app/javascript/controllers/review_modal_controller.js
@@ -2,13 +2,23 @@ import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="review-modal"
 export default class extends Controller {
-  static targets = ["reviewModal"]
+  static targets = ["reviewModal", "backGround"]
   connect() {
   }
 
   close(event) {
     if (event.detail.success) {
-      this.reviewModalTarget.classList.add("hidden");
+      this.backGroundTarget.classList.add("hidden");
+    }
+  }
+
+  closeModal() {
+    this.backGroundTarget.classList.add("hidden");
+  }
+
+  closeBackground(event) {
+    if(event.target === this.backGroundTarget) {
+      this.closeModal();
     }
   }
 }

--- a/app/views/reviews/edit.html.erb
+++ b/app/views/reviews/edit.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag 'review_modal' do %>
-  <div class="fixed inset-0 flex items-center justify-center z-50 bg-gray-500 bg-opacity-50" data-controller="review-modal" data-review-modal-target="reviewModal">
-    <div class="modal-content bg-white rounded-xl shadow-lg p-10 w-18 md: w-[450px]">
+  <div class="fixed inset-0 flex items-center justify-center z-50 bg-gray-500 bg-opacity-50" data-controller="review-modal" data-review-modal-target="backGround" data-action="click->review-modal#closeBackground">
+    <div class="modal-content bg-white rounded-xl shadow-lg p-10 w-18 md:w-[450px]" data-review-modal-target="reviewModal">
       <%= form_with model: @review, url: review_path(@review), data: { action: "turbo:submit-end->review-modal#close" }, method: :patch do |f| %>
         <%= render 'shared/error_messages', object: f.object %>
         <div class="max-w-lg mx-auto p-2 md:p-6 bg-white rounded-xl space-y-2 md:space-y-4">
@@ -13,7 +13,7 @@
           </div>
 
           <%= f.submit '更新する', class: 'w-full py-2 px-4 bg-yellow-500 text-white rounded-xl hover:bg-yellow-600 focus:outline-none focus:ring focus:ring-yellow-200' %>
-          <button class="w-full py-2 px-4 bg-gray-500 text-white rounded-xl hover:bg-gray-600 focus:outline-none focus:ring forcus:ring-gray-200" data-action="turbo:click->review-modal#close">キャンセル</button>
+          <p class="w-full py-2 px-4 bg-gray-500 text-white text-center rounded-xl hover:bg-gray-600 focus:outline-none focus:ring forcus:ring-gray-200" data-action="click->review-modal#closeModal">キャンセル</p>
         </div>
       <% end %>      
     </div>

--- a/app/views/reviews/new.html.erb
+++ b/app/views/reviews/new.html.erb
@@ -1,6 +1,9 @@
 <%= turbo_frame_tag 'review_modal' do %>
-  <div class="fixed inset-0 flex items-center justify-center z-50 bg-gray-500 bg-opacity-50" data-controller="review-modal" data-review-modal-target="reviewModal">
-    <div class="modal-content bg-white rounded-xl shadow-lg p-10 w-18 md: w-[450px]">
+  <div class="fixed inset-0 flex items-center justify-center z-50 bg-gray-500 bg-opacity-50" data-controller="review-modal" data-review-modal-target="backGround" data-action="click->review-modal#closeBackground">
+    <div class="modal-content bg-white rounded-xl shadow-lg p-10 w-18 md:w-[450px]" data-review-modal-target="reviewModal">
+      <div class="flex justify-end items-center">
+        <i class="fa-solid fa-xmark h-6 w-6 hover:text-yellow-500" data-action="click->review-modal#closeModal"></i>
+      </div>
       <%= form_with model: @review, url: shop_reviews_path(@shop), data: { action: "turbo:submit-end->review-modal#close" }, method: :post do |f| %>
         <%= render 'shared/error_messages', object: f.object %>
         <div class="max-w-lg mx-auto p-2 md:p-6 bg-white rounded-xl space-y-2 md:space-y-4">


### PR DESCRIPTION
## 内容
- レビュー作成、編集用のモーダルについて、モーダル外をクリックすると、モーダルが閉じるように修正しました。

## 確認事項
- レビュー作成用のモーダルの外をクリックするとモーダルが閉じているか。
- レビュー編集用のモーダルの外をクリックするとモーダルが閉じているか。

## 確認結果
「レビュー作成時のモーダル」
![30e776803191c282cd15d2c1226a0dc0](https://github.com/jinta-shimo02/fuku_cafe/assets/100778581/c69919aa-b472-4471-a5b1-15983b33f192)

「レビュー編集時のモーダル」
![d6dcd09339b9cb11e8d68facfbf03f97](https://github.com/jinta-shimo02/fuku_cafe/assets/100778581/064ae97b-9c30-467d-8f5c-5bedb66d15cc)